### PR TITLE
[feat] ping 기반 쿠키 초기화 및 로그인 로직 리팩토링

### DIFF
--- a/src/AppInitializer.tsx
+++ b/src/AppInitializer.tsx
@@ -1,11 +1,11 @@
 import { useEffect } from "react";
-import { ensureCsrf } from "@/apis/axios-instance";
+import { getPing } from "@/apis/axios-instance";
 import { RouterProvider } from "react-router-dom";
 import { router } from "./routes";
 
 export function AppInitializer() {
   useEffect(() => {
-    ensureCsrf();
+    getPing();
   }, []);
 
   return <RouterProvider router={router} />;

--- a/src/apis/auth/signin.ts
+++ b/src/apis/auth/signin.ts
@@ -1,9 +1,5 @@
 import { axiosInstance } from "../axios-instance";
 
-export const initCsrf = async () => {
-  await axiosInstance.get("/csrf", { withCredentials: true });
-};
-
 export const postSignin = async (email: string, password: string) => {
   const formData = new URLSearchParams();
   formData.append("username", email);

--- a/src/apis/axios-instance.ts
+++ b/src/apis/axios-instance.ts
@@ -15,45 +15,21 @@ export const axiosInstance: AxiosInstance = axios.create({
 });
 
 let csrfTokenCache = "";
-let csrfInitPromise: Promise<void> | null = null;
 
-export const ensureCsrf = async (): Promise<void> => {
-  if (csrfTokenCache) return;
+export const getPing = async (): Promise<void> => {
+  try {
+    await axiosInstance.get("/public/ping");
 
-  if (csrfInitPromise) {
-    await csrfInitPromise;
-    return;
-  }
-
-  csrfInitPromise = (async () => {
-    try {
-      await axiosInstance.get("/csrf", { withCredentials: true });
-
-      const match = document.cookie.match(/XSRF-TOKEN=([^;]+)/);
-      if (match) {
-        csrfTokenCache = decodeURIComponent(match[1]);
-        console.info("쿠키에서 CSRF 토큰을 읽어왔습니다: ", csrfTokenCache);
-      } else {
-        console.warn("/csrf 요청 이후에도 쿠키에 XSRF-TOKEN이 존재하지 않습니다.");
-      }
-
-      const commonHeaders = axiosInstance.defaults.headers.common;
-      if (commonHeaders instanceof AxiosHeaders) {
-        commonHeaders.set("X-XSRF-TOKEN", csrfTokenCache);
-      } else {
-        axiosInstance.defaults.headers.common = new AxiosHeaders({
-          ...(commonHeaders || {}),
-          "X-XSRF-TOKEN": csrfTokenCache,
-        });
-      }
-    } catch (err) {
-      console.error("CSRF 초기화 실패:", err);
-    } finally {
-      csrfInitPromise = null;
+    const match = document.cookie.match(/XSRF-TOKEN=([^;]+)/);
+    if (match) {
+      csrfTokenCache = decodeURIComponent(match[1]);
+      console.info("쿠키에서 XSRF-TOKEN 읽어옴:", csrfTokenCache);
+    } else {
+      console.warn("/ping 요청 후에도 XSRF-TOKEN 쿠키가 존재하지 않습니다.");
     }
-  })();
-
-  await csrfInitPromise;
+  } catch (error) {
+    console.error("Ping 요청 실패:", error);
+  }
 };
 
 axiosInstance.interceptors.request.use(
@@ -62,7 +38,7 @@ axiosInstance.interceptors.request.use(
 
     if (["POST", "PUT", "PATCH", "DELETE"].includes(method)) {
       if (!csrfTokenCache) {
-        await ensureCsrf();
+        await getPing();
       }
 
       const headers =
@@ -80,7 +56,7 @@ axiosInstance.interceptors.response.use(
   (response: AxiosResponse) => response,
   async (error: AxiosError) => {
     if (error.response?.status === 401) {
-      console.warn("세션 만료 감지 -> CSRF 토큰 초기화");
+      console.warn("세션 만료 감지 → 쿠키 초기화");
       csrfTokenCache = "";
       window.location.href = "/auth/signin";
     }

--- a/src/hooks/auth/useAuth.ts
+++ b/src/hooks/auth/useAuth.ts
@@ -1,5 +1,5 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
-import { initCsrf, postSignin, postSignout } from "@/apis/auth/signin";
+import { postSignin, postSignout } from "@/apis/auth/signin";
 import {
   postEmailResend,
   postEmailVerification,
@@ -76,7 +76,6 @@ export const useSignin = () => {
   return useMutation({
     mutationKey: ["signin"],
     mutationFn: async (credentials: { email: string; password: string }) => {
-      await initCsrf();
       return await postSignin(credentials.email, credentials.password);
     },
     onSuccess: async () => {
@@ -103,7 +102,6 @@ export const useSignout = () => {
   return useMutation({
     mutationKey: ["signout"],
     mutationFn: async () => {
-      await initCsrf();
       await postSignout();
     },
     onSuccess: async () => {


### PR DESCRIPTION
### 🔍 작업 개요
- `/csrf` 기반 초기화 로직을 `/ping` 기반으로 단순화
- Axios 인스턴스에서 쿠키 기반 CSRF 토큰 자동 주입 구조로 리팩토링
- 로그인 관련 훅(`useAuth`) 및 초기화 로직(`AppInitializer`) 수정

---

### ✨ 주요 변경사항
1. **Axios 인스턴스 개선**
   - `ensureCsrf()` 제거 → `/ping` 요청으로 세션 및 XSRF-TOKEN 쿠키 생성
   - `document.cookie`에서 XSRF-TOKEN 읽어 `X-XSRF-TOKEN` 헤더에 자동 설정
   - 요청 인터셉터에서 `POST`, `PUT`, `PATCH`, `DELETE` 메서드에만 CSRF 헤더 주입

2. **초기화 로직**
   - `AppInitializer.tsx`에서 `ensureCsrf()` → `getPing()` 호출로 변경
   - 앱 최초 실행 시 쿠키 세션 자동 생성 및 토큰 캐싱

3. **인증 로직**
   - `useAuth` 훅 내부 로그인/로그아웃 로직 axios 변경 사항 반영
   - `/login` 요청 시 쿠키 기반 CSRF 헤더 자동 처리

---

### 🧪 테스트
- [x] 쿠키 초기화 후 `/ping` 요청 시 XSRF-TOKEN 쿠키 정상 생성 확인  
- [x] 로그인 요청 시 헤더의 `X-XSRF-TOKEN` 값이 쿠키와 일치함  
- [x] 로그인 성공 시 200 응답 및 `JSESSIONID` 쿠키 발급 확인  
- [x] `/csrf` 호출 제거 후에도 모든 POST 요청 정상 동작  
- [x] 세션 만료(401) 시 자동 리다이렉트 정상 작동  

---

### 📚 기타
- `/csrf` API 완전히 제거 → CSRF & SSRP 쿠키 충돌 해결  
- `/ping` 호출만으로 세션 및 토큰 생성 가능  
- 추후 `/ping` 응답 구조 확장 시 `getPing()` 내부에서만 수정 필요
