### PR TITLE
[Feat] 커뮤니티 (자유게시판) - 1차 목록/상세/등록 UI 및 기능 구현

### DIFF
--- a/src/apis/board/getBoardDetail.ts
+++ b/src/apis/board/getBoardDetail.ts
@@ -1,0 +1,9 @@
+import { axiosInstance } from "@/apis/axios-instance";
+import type { BoardDetailResponse } from "@/types/boardDetail";
+
+export const getBoardDetail = async (boardId: string): Promise<BoardDetailResponse> => {
+  const { data } = await axiosInstance.get<BoardDetailResponse>(`/api/board/{boardId}`, {
+    params: { boardId },
+  });
+  return data;
+};

--- a/src/apis/board/getBoardList.ts
+++ b/src/apis/board/getBoardList.ts
@@ -6,6 +6,7 @@ export const getBoardList = async (params: BoardQuery): Promise<BoardListRespons
   const queryParams = boardType ? { ...rest, boardType } : rest;
 
   const { data } = await axiosInstance.get<BoardListResponse>(
+    // 백엔드 수정 예정
     `/api/board/boards/{boardType}${boardType ?? ""}`,
     { params: queryParams }
   );

--- a/src/apis/board/getBoardList.ts
+++ b/src/apis/board/getBoardList.ts
@@ -1,0 +1,14 @@
+import { axiosInstance } from "@/apis/axios-instance";
+import type { BoardListResponse, BoardQuery } from "@/types/board";
+
+export const getBoardList = async (params: BoardQuery): Promise<BoardListResponse> => {
+  const { boardType, ...rest } = params;
+  const queryParams = boardType ? { ...rest, boardType } : rest;
+
+  const { data } = await axiosInstance.get<BoardListResponse>(
+    `/api/board/boards/{boardType}${boardType ?? ""}`,
+    { params: queryParams }
+  );
+
+  return data;
+};

--- a/src/apis/board/postBoard.ts
+++ b/src/apis/board/postBoard.ts
@@ -1,0 +1,6 @@
+import { axiosInstance } from "@/apis/axios-instance";
+import type { BoardPostRequest } from "@/types/board";
+
+export const postBoard = async (payload: BoardPostRequest) => {
+  return axiosInstance.post("/api/board/create", payload);
+};

--- a/src/assets/icons/index.ts
+++ b/src/assets/icons/index.ts
@@ -22,4 +22,5 @@ export {
   CheckCircle,
   ArrowUpDownIcon,
   ChevronDownIcon,
+  SearchIcon,
 } from "lucide-react";

--- a/src/components/community/board/boardDetails/BoardComments.tsx
+++ b/src/components/community/board/boardDetails/BoardComments.tsx
@@ -1,0 +1,24 @@
+import type { CommentItem } from "@/types/boardDetail";
+import { format } from "date-fns";
+
+interface Props {
+  comments: CommentItem[];
+}
+
+export const BoardComments = ({ comments }: Props) => {
+  return (
+    <div className='mt-6'>
+      {comments.map((c) => (
+        <div key={c.id} className='py-3 border-b'>
+          <div className='flex items-center gap-2 text-sm text-gray-500'>
+            <div className='w-6 h-6 rounded-full bg-gray-200' />
+            <span>{c.creatorNickname}</span>
+            <span>{format(new Date(c.createdAt), "MM/dd HH:mm")}</span>
+          </div>
+
+          <p className='mt-2'>{c.content}</p>
+        </div>
+      ))}
+    </div>
+  );
+};

--- a/src/components/community/board/boardDetails/BoardDetailContent.tsx
+++ b/src/components/community/board/boardDetails/BoardDetailContent.tsx
@@ -1,0 +1,9 @@
+import type { BoardDetail } from "@/types/boardDetail";
+
+interface Props {
+  board: BoardDetail;
+}
+
+export const BoardDetailContent = ({ board }: Props) => {
+  return <p className='mt-4 text-gray-700 whitespace-pre-line'>{board.content}</p>;
+};

--- a/src/components/community/board/boardDetails/BoardDetailHeader.tsx
+++ b/src/components/community/board/boardDetails/BoardDetailHeader.tsx
@@ -1,0 +1,24 @@
+import { UserRound } from "lucide-react";
+import type { BoardDetail } from "@/types/boardDetail";
+import { format } from "date-fns";
+
+interface Props {
+  board: BoardDetail;
+}
+
+export const BoardDetailHeader = ({ board }: Props) => {
+  const date = format(new Date(board.createdAt), "MM/dd HH:mm");
+
+  return (
+    <div className='flex items-start gap-3 mb-4'>
+      <div className='w-10 h-10 rounded-full bg-gray-200 flex items-center justify-center'>
+        <UserRound className='w-6 h-6 text-gray-500' />
+      </div>
+
+      <div className='flex flex-col'>
+        <span className='font-semibold text-base'>{board.creatorNickname}</span>
+        <span className='text-xs text-gray-500'>{date}</span>
+      </div>
+    </div>
+  );
+};

--- a/src/components/community/board/boardDetails/BoardDetailImages.tsx
+++ b/src/components/community/board/boardDetails/BoardDetailImages.tsx
@@ -15,7 +15,7 @@ export const BoardDetailImages = ({ images }: Props) => {
       <img
         src={images[0]}
         alt='board'
-        className='w-full h-full object-cover'
+        className='w-full h-full object-contain'
         onError={(e) => {
           (e.currentTarget as HTMLImageElement).src = defaultImg;
         }}

--- a/src/components/community/board/boardDetails/BoardDetailImages.tsx
+++ b/src/components/community/board/boardDetails/BoardDetailImages.tsx
@@ -1,0 +1,25 @@
+import defaultImg from "@/assets/images/default.png";
+
+interface Props {
+  images: string[];
+}
+
+export const BoardDetailImages = ({ images }: Props) => {
+  if (!images || images.length === 0)
+    return (
+      <div className='w-full h-60 bg-gray-200 flex items-center justify-center rounded-lg'>img</div>
+    );
+
+  return (
+    <div className='w-full h-60 rounded-lg overflow-hidden'>
+      <img
+        src={images[0]}
+        alt='board'
+        className='w-full h-full object-cover'
+        onError={(e) => {
+          (e.currentTarget as HTMLImageElement).src = defaultImg;
+        }}
+      />
+    </div>
+  );
+};

--- a/src/components/community/board/boardDetails/CommentInputBar.tsx
+++ b/src/components/community/board/boardDetails/CommentInputBar.tsx
@@ -1,0 +1,28 @@
+import { Send } from "lucide-react";
+import { Input } from "@/components/ui/input";
+
+interface Props {
+  comment: string;
+  onChange: (v: string) => void;
+  onSubmit: () => void;
+}
+
+export const CommentInputBar = ({ comment, onChange, onSubmit }: Props) => {
+  return (
+    <div className='fixed bottom-0 left-0 right-0 max-w-[430px] mx-auto w-full flex gap-2 bg-white border-t border-gray-100 px-4 py-3'>
+      <Input
+        value={comment}
+        onChange={(e) => onChange(e.target.value)}
+        placeholder='댓글을 입력하세요'
+        className='rounded-full bg-gray-100 border-none focus-visible:ring-gray-300 px-4 py-2'
+      />
+
+      <button
+        className='min-w-10 min-h-10 bg-gray-200 rounded-full flex items-center justify-center'
+        onClick={onSubmit}
+      >
+        <Send size={18} />
+      </button>
+    </div>
+  );
+};

--- a/src/components/community/board/boardList/BoardCard.tsx
+++ b/src/components/community/board/boardList/BoardCard.tsx
@@ -1,0 +1,92 @@
+import type { BoardItem } from "@/types/board";
+import defaultThumbnail from "@/assets/images/default.png";
+import { ThumbsUp, MessageSquare } from "lucide-react";
+
+interface BoardCardProps {
+  post: BoardItem;
+}
+
+export const BoardCard = ({ post }: BoardCardProps) => {
+  const { title, content, boardType, createdAt, images, comments } = post;
+
+  const hasImages = Array.isArray(images) && images.length > 0;
+  const validSrc = hasImages ? images[0] : undefined;
+
+  const likeCount = 0;
+  const commentCount = Array.isArray(comments) ? comments.length : 0;
+
+  const getBoardTypeLabel = (type: string): string => {
+    switch (type) {
+      case "FREE":
+        return "자유";
+      case "INFO":
+        return "정보공유";
+      case "QNA":
+        return "FAQ";
+      default:
+        return "자유";
+    }
+  };
+
+  const getRelativeTime = (dateString: string): string => {
+    const date = new Date(dateString);
+    const now = new Date();
+    const diffMs = now.getTime() - date.getTime();
+
+    const minutes = Math.floor(diffMs / (1000 * 60));
+    const hours = Math.floor(diffMs / (1000 * 60 * 60));
+    const days = Math.floor(diffMs / (1000 * 60 * 60 * 24));
+
+    if (minutes < 1) return "방금 전";
+    if (minutes < 60) return `${minutes}분 전`;
+    if (hours < 24) return `${hours}시간 전`;
+    if (days < 7) return `${days}일 전`;
+
+    return date.toLocaleDateString("ko-KR", {
+      year: "numeric",
+      month: "long",
+      day: "numeric",
+    });
+  };
+
+  return (
+    <div className='flex gap-3 bg-white p-4 hover:bg-gray-50 cursor-pointer rounded-lg'>
+      {hasImages && (
+        <div className='w-20 h-20 rounded-lg overflow-hidden bg-gray-100 shrink-0'>
+          <img
+            src={validSrc}
+            alt={title}
+            className='w-full h-full object-cover'
+            onError={(e) => {
+              e.currentTarget.src = defaultThumbnail;
+            }}
+          />
+        </div>
+      )}
+
+      <div className='flex flex-col flex-1 min-w-0'>
+        <h3 className='text-base font-semibold truncate'>{title}</h3>
+        <p className='text-sm text-gray-600 truncate'>{content}</p>
+
+        <div className='flex flex-col justify-between mt-2 flex-1'>
+          <div className='flex items-center text-xs text-gray-400'>
+            <span>{getBoardTypeLabel(boardType)}</span>
+            <span className='mx-1'>•</span>
+            <span>{getRelativeTime(createdAt)}</span>
+          </div>
+
+          <div className='flex items-center gap-3 mt-1 text-gray-500 text-sm'>
+            <div className='flex items-center gap-1'>
+              <ThumbsUp className='w-4 h-4' />
+              <span>{likeCount}</span>
+            </div>
+            <div className='flex items-center gap-1'>
+              <MessageSquare className='w-4 h-4' />
+              <span>{commentCount}</span>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/src/components/community/board/boardList/BoardCard.tsx
+++ b/src/components/community/board/boardList/BoardCard.tsx
@@ -1,6 +1,7 @@
 import type { BoardItem } from "@/types/board";
 import defaultThumbnail from "@/assets/images/default.png";
 import { ThumbsUp, MessageSquare } from "lucide-react";
+import { useNavigate } from "react-router-dom";
 
 interface BoardCardProps {
   post: BoardItem;
@@ -8,6 +9,11 @@ interface BoardCardProps {
 
 export const BoardCard = ({ post }: BoardCardProps) => {
   const { title, content, boardType, createdAt, images, comments } = post;
+  const navigate = useNavigate();
+
+  const handleClick = () => {
+    navigate(`/community/board/${post.id}`);
+  };
 
   const hasImages = Array.isArray(images) && images.length > 0;
   const validSrc = hasImages ? images[0] : undefined;
@@ -50,7 +56,10 @@ export const BoardCard = ({ post }: BoardCardProps) => {
   };
 
   return (
-    <div className='flex gap-3 bg-white p-4 hover:bg-gray-50 cursor-pointer rounded-lg'>
+    <div
+      className='flex gap-3 bg-white p-4 hover:bg-gray-50 cursor-pointer rounded-lg'
+      onClick={handleClick}
+    >
       {hasImages && (
         <div className='w-20 h-20 rounded-lg overflow-hidden bg-gray-100 shrink-0'>
           <img

--- a/src/components/community/board/boardList/BoardHeader.tsx
+++ b/src/components/community/board/boardList/BoardHeader.tsx
@@ -1,0 +1,33 @@
+import { SearchBar } from "./filters/SearchBar";
+import { SortFilter } from "./filters/SortFilter";
+import { BoardTypeFilter } from "./filters/BoardTypeFilter";
+import type { BoardType } from "@/types/board";
+
+interface BoardHeaderProps {
+  sort?: "popular" | "latest";
+  boardType?: BoardType;
+  onChangeSort: (v: "popular" | "latest") => void;
+  onChangeBoardType: (v?: BoardType) => void;
+  onSearch: (keyword: string) => void;
+}
+
+export function BoardHeader({
+  sort,
+  boardType,
+  onChangeSort,
+  onChangeBoardType,
+  onSearch,
+}: BoardHeaderProps) {
+  return (
+    <div className='flex flex-col gap-2 bg-white px-3 py-2 border-b border-gray-200'>
+      {/* 검색창 */}
+      <SearchBar onSearch={onSearch} />
+
+      {/* 필터 그룹 */}
+      <div className='flex gap-2 overflow-x-auto no-scrollbar py-1'>
+        <SortFilter value={sort} onChange={onChangeSort} />
+        <BoardTypeFilter value={boardType} onChange={onChangeBoardType} />
+      </div>
+    </div>
+  );
+}

--- a/src/components/community/board/boardList/BoardList.tsx
+++ b/src/components/community/board/boardList/BoardList.tsx
@@ -1,0 +1,51 @@
+import { useRef, useEffect } from "react";
+import { useGetBoardList } from "@/hooks/board/useGetBoardList";
+import { BoardCard } from "./BoardCard";
+import type { BoardListResponse } from "@/types/board";
+
+interface BoardListProps {
+  boardType?: "FREE" | "QNA" | "INFO";
+  sort?: "popular" | "latest";
+  keyword?: string;
+}
+
+export const BoardList = ({ boardType }: BoardListProps) => {
+  const { data, fetchNextPage, hasNextPage, isFetchingNextPage, status, error } = useGetBoardList({
+    boardType,
+    size: 20,
+  });
+
+  const observerRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    if (!observerRef.current) return;
+    const observer = new IntersectionObserver(
+      (entries) => {
+        if (entries[0].isIntersecting && hasNextPage) fetchNextPage();
+      },
+      { threshold: 0.2 }
+    );
+    observer.observe(observerRef.current);
+    return () => observer.disconnect();
+  }, [fetchNextPage, hasNextPage]);
+
+  const posts = data?.pages.flatMap((page: BoardListResponse) => page.items) ?? [];
+
+  if (status === "error") {
+    return <div className='text-red-500'>에러 발생: {error.message}</div>;
+  }
+
+  return (
+    <div className='flex flex-col gap-3'>
+      {posts.length > 0 ? (
+        posts.map((post) => <BoardCard key={post.id} post={post} />)
+      ) : (
+        <div className='text-gray-400 text-center py-6'>게시글이 없습니다.</div>
+      )}
+
+      <div ref={observerRef} className='h-8 flex justify-center items-center text-gray-400 text-sm'>
+        {isFetchingNextPage ? "불러오는 중..." : hasNextPage ? "스크롤로 더 보기" : ""}
+      </div>
+    </div>
+  );
+};

--- a/src/components/community/board/boardList/GotoPostBtn.tsx
+++ b/src/components/community/board/boardList/GotoPostBtn.tsx
@@ -1,0 +1,29 @@
+import { Button } from "@/components/ui/button";
+import { useNavigate } from "react-router-dom";
+import { Edit } from "lucide-react";
+
+export const GotoPostBtn = () => {
+  const navigate = useNavigate();
+
+  const handleClick = () => {
+    navigate("post");
+  };
+
+  return (
+    <Button
+      className='
+        fixed bottom-15 right-6
+        rounded-full px-6 py-3
+        bg-[var(--color-mint-light)]
+        text-white font-semibold
+        hover:bg-[var(--color-mint-dark)]
+        transition-all
+        flex gap-2
+      '
+      onClick={handleClick}
+    >
+      <Edit className='w-4' />
+      글쓰기
+    </Button>
+  );
+};

--- a/src/components/community/board/boardList/filters/BoardTypeFilter.tsx
+++ b/src/components/community/board/boardList/filters/BoardTypeFilter.tsx
@@ -1,0 +1,33 @@
+import { Button } from "@/components/ui/button";
+import type { BoardType } from "@/types/board";
+
+interface BoardTypeFilterProps {
+  value?: BoardType;
+  onChange: (v?: BoardType) => void;
+}
+
+export function BoardTypeFilter({ value, onChange }: BoardTypeFilterProps) {
+  const tabs: { label: string; type?: BoardType }[] = [
+    { label: "자유", type: "FREE" },
+    { label: "정보공유", type: "INFO" },
+    { label: "FAQ", type: "QNA" },
+  ];
+
+  return (
+    <>
+      {tabs.map(({ label, type }) => (
+        <Button
+          key={label}
+          onClick={() => onChange(type)}
+          className={`h-9 rounded-full border transition-colors ${
+            value === type
+              ? "bg-gray-700 text-white border-gray-700"
+              : "bg-white text-gray-700 border-gray-300 hover:bg-gray-100"
+          }`}
+        >
+          {label}
+        </Button>
+      ))}
+    </>
+  );
+}

--- a/src/components/community/board/boardList/filters/SearchBar.tsx
+++ b/src/components/community/board/boardList/filters/SearchBar.tsx
@@ -1,0 +1,38 @@
+import { useState } from "react";
+import { SearchIcon } from "@/assets/icons";
+
+interface SearchBarProps {
+  onSearch: (keyword: string) => void;
+}
+
+export function SearchBar({ onSearch }: SearchBarProps) {
+  const [keyword, setKeyword] = useState("");
+
+  const handleSearch = () => {
+    const trimmed = keyword.trim();
+    if (trimmed) onSearch(trimmed);
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === "Enter") handleSearch();
+  };
+
+  return (
+    <div className='flex items-center border border-gray-300 rounded-full px-3 py-1.5 bg-white'>
+      <input
+        type='text'
+        value={keyword}
+        onChange={(e) => setKeyword(e.target.value)}
+        onKeyDown={handleKeyDown}
+        placeholder='검색어를 입력해주세요'
+        className='flex-1 bg-transparent outline-none text-sm text-gray-700'
+      />
+      <button
+        onClick={handleSearch}
+        className='rounded-full bg-[var(--color-mint-light,#6fd0c2)] p-1.5'
+      >
+        <SearchIcon className='size-4 text-white' />
+      </button>
+    </div>
+  );
+}

--- a/src/components/community/board/boardList/filters/SortFilter.tsx
+++ b/src/components/community/board/boardList/filters/SortFilter.tsx
@@ -1,0 +1,41 @@
+import { ChevronDownIcon } from "@/assets/icons";
+import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuTrigger,
+  DropdownMenuContent,
+  DropdownMenuItem,
+} from "@/components/ui/dropdown-menu";
+
+interface SortFilterProps {
+  value?: "popular" | "latest";
+  onChange: (v: "popular" | "latest") => void;
+}
+
+export function SortFilter({ value, onChange }: SortFilterProps) {
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button className='h-9 rounded-full bg-white border border-gray-300 text-gray-700 hover:bg-gray-100'>
+          {value === "popular" ? "인기순" : "최신순"}
+          <ChevronDownIcon className='ml-1 size-4' />
+        </Button>
+      </DropdownMenuTrigger>
+
+      <DropdownMenuContent className='p-1 min-w-[8rem]'>
+        <DropdownMenuItem
+          onClick={() => onChange("popular")}
+          className={value === "popular" ? "bg-gray-100 font-semibold" : ""}
+        >
+          인기순
+        </DropdownMenuItem>
+        <DropdownMenuItem
+          onClick={() => onChange("latest")}
+          className={value === "latest" ? "bg-gray-100 font-semibold" : ""}
+        >
+          최신순
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}

--- a/src/components/community/board/boardPost/BoardTypeSelect.tsx
+++ b/src/components/community/board/boardPost/BoardTypeSelect.tsx
@@ -1,0 +1,46 @@
+import type { BoardType } from "@/types/board";
+import {
+  DropdownMenu,
+  DropdownMenuTrigger,
+  DropdownMenuContent,
+  DropdownMenuItem,
+} from "@/components/ui/dropdown-menu";
+import { ChevronDown } from "lucide-react";
+
+const TYPE_OPTIONS: { label: string; value: BoardType }[] = [
+  { label: "자유", value: "FREE" },
+  { label: "정보공유", value: "INFO" },
+  { label: "FAQ", value: "QNA" },
+];
+
+interface Props {
+  value: BoardType;
+  onChange: (v: BoardType) => void;
+}
+
+export const BoardTypeSelect = ({ value, onChange }: Props) => {
+  const selectedLabel = TYPE_OPTIONS.find((t) => t.value === value)?.label ?? "자유";
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <button className='w-32 flex items-center gap-1 bg-gray-100 px-3 py-1.5 rounded-full text-sm justify-between'>
+          {selectedLabel}
+          <ChevronDown size={16} />
+        </button>
+      </DropdownMenuTrigger>
+
+      <DropdownMenuContent className='w-32'>
+        {TYPE_OPTIONS.map((type) => (
+          <DropdownMenuItem
+            key={type.value}
+            onClick={() => onChange(type.value)}
+            className='cursor-pointer'
+          >
+            {type.label}
+          </DropdownMenuItem>
+        ))}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+};

--- a/src/components/community/board/boardPost/PhotoUploader.tsx
+++ b/src/components/community/board/boardPost/PhotoUploader.tsx
@@ -1,0 +1,36 @@
+import { Camera, X } from "lucide-react";
+
+interface Props {
+  images: string[];
+  onAdd: (file: File) => void;
+  onRemove: (index: number) => void;
+}
+
+export const PhotoUploader = ({ images, onAdd, onRemove }: Props) => {
+  const handleUpload = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (file) onAdd(file);
+  };
+
+  return (
+    <div className='flex gap-3 mt-4'>
+      <label className='w-16 h-16 bg-gray-100 rounded-xl flex items-center justify-center cursor-pointer'>
+        <Camera className='w-7 h-7 text-gray-500' />
+        <input type='file' accept='image/*' className='hidden' onChange={handleUpload} />
+      </label>
+
+      {images.map((img, idx) => (
+        <div key={idx} className='relative w-16 h-16 rounded-xl overflow-hidden'>
+          <img src={img} className='w-full h-full object-cover' />
+
+          <button
+            onClick={() => onRemove(idx)}
+            className='absolute top-1 right-1 bg-black/50 rounded-full p-1'
+          >
+            <X className='w-3 h-3 text-white' />
+          </button>
+        </div>
+      ))}
+    </div>
+  );
+};

--- a/src/components/ui/badge.tsx
+++ b/src/components/ui/badge.tsx
@@ -1,46 +1,39 @@
-import * as React from "react"
-import { Slot } from "@radix-ui/react-slot"
-import { cva, type VariantProps } from "class-variance-authority"
+import * as React from "react";
+import { Slot } from "@radix-ui/react-slot";
+import { cva, type VariantProps } from "class-variance-authority";
 
-import { cn } from "@/lib/utils"
+import { cn } from "@/lib/utils";
 
 const badgeVariants = cva(
   "inline-flex items-center justify-center rounded-full border px-2 py-0.5 text-xs font-medium w-fit whitespace-nowrap shrink-0 [&>svg]:size-3 gap-1 [&>svg]:pointer-events-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive transition-[color,box-shadow] overflow-hidden",
   {
     variants: {
       variant: {
-        default:
-          "border-transparent bg-primary text-primary-foreground [a&]:hover:bg-primary/90",
+        default: "border-transparent bg-primary text-primary-foreground [a&]:hover:bg-primary/90",
         secondary:
           "border-transparent bg-secondary text-secondary-foreground [a&]:hover:bg-secondary/90",
         destructive:
           "border-transparent bg-destructive text-white [a&]:hover:bg-destructive/90 focus-visible:ring-destructive/20 dark:focus-visible:ring-destructive/40 dark:bg-destructive/60",
-        outline:
-          "text-foreground [a&]:hover:bg-accent [a&]:hover:text-accent-foreground",
+        outline: "text-foreground [a&]:hover:bg-accent [a&]:hover:text-accent-foreground",
       },
     },
     defaultVariants: {
       variant: "default",
     },
   }
-)
+);
 
 function Badge({
   className,
   variant,
   asChild = false,
   ...props
-}: React.ComponentProps<"span"> &
-  VariantProps<typeof badgeVariants> & { asChild?: boolean }) {
-  const Comp = asChild ? Slot : "span"
+}: React.ComponentProps<"span"> & VariantProps<typeof badgeVariants> & { asChild?: boolean }) {
+  const Comp = asChild ? Slot : "span";
 
   return (
-    <Comp
-      data-slot="badge"
-      className={cn(badgeVariants({ variant }), className)}
-      {...props}
-    />
-  )
+    <Comp data-slot='badge' className={cn(badgeVariants({ variant }), className)} {...props} />
+  );
 }
 
-export { Badge, badgeVariants }
+export { Badge };

--- a/src/config/navMenu.ts
+++ b/src/config/navMenu.ts
@@ -1,5 +1,5 @@
 import type { LucideIcon } from "lucide-react";
-import { QrCode, Leaf, Users, MessageSquare, User, HelpCircle } from "lucide-react";
+import { QrCode, Leaf, Users, MessageSquare, User, HelpCircle, Home } from "lucide-react";
 
 export interface NavChild {
   label: string;
@@ -16,6 +16,11 @@ export interface NavCategory {
 }
 
 export const mainMenu: NavCategory[] = [
+  {
+    label: "홈",
+    icon: Home,
+    path: "/home",
+  },
   {
     label: "QR",
     icon: QrCode,

--- a/src/hooks/board/useGetBoardDetail.ts
+++ b/src/hooks/board/useGetBoardDetail.ts
@@ -1,0 +1,9 @@
+import { useQuery } from "@tanstack/react-query";
+import { getBoardDetail } from "@/apis/board/getBoardDetail";
+
+export const useGetBoardDetail = (boardId: string) => {
+  return useQuery({
+    queryKey: ["boardDetail", boardId],
+    queryFn: () => getBoardDetail(boardId),
+  });
+};

--- a/src/hooks/board/useGetBoardList.ts
+++ b/src/hooks/board/useGetBoardList.ts
@@ -1,0 +1,18 @@
+import { useInfiniteQuery, type InfiniteData } from "@tanstack/react-query";
+import { getBoardList } from "@/apis/board/getBoardList";
+import type { BoardListResponse, BoardQuery } from "@/types/board";
+
+export const useGetBoardList = (params: BoardQuery) => {
+  return useInfiniteQuery<
+    BoardListResponse,
+    Error,
+    InfiniteData<BoardListResponse>,
+    (string | BoardQuery)[],
+    string | undefined
+  >({
+    queryKey: ["boardList", params],
+    queryFn: ({ pageParam }) => getBoardList({ ...params, cursor: pageParam }),
+    initialPageParam: undefined,
+    getNextPageParam: (lastPage) => (lastPage.hasNext ? lastPage.nextCursor : undefined),
+  });
+};

--- a/src/hooks/board/usePostBoard.ts
+++ b/src/hooks/board/usePostBoard.ts
@@ -1,0 +1,10 @@
+import { useMutation } from "@tanstack/react-query";
+import { postBoard } from "@/apis/board/postBoard";
+import type { BoardPostRequest } from "@/types/board";
+
+export const usePostBoard = () => {
+  return useMutation({
+    mutationKey: ["postBoard"],
+    mutationFn: (payload: BoardPostRequest) => postBoard(payload),
+  });
+};

--- a/src/pages/community/CommunityExchangePage.tsx
+++ b/src/pages/community/CommunityExchangePage.tsx
@@ -1,0 +1,5 @@
+const CommunityExchange = () => {
+  return <div>CommunityExchange</div>;
+};
+
+export default CommunityExchange;

--- a/src/pages/community/CommunityPage.tsx
+++ b/src/pages/community/CommunityPage.tsx
@@ -1,5 +1,0 @@
-const CommunityPage = () => {
-  return <div>CommunityPage</div>;
-};
-
-export default CommunityPage;

--- a/src/pages/community/board/BoardDetailPage.tsx
+++ b/src/pages/community/board/BoardDetailPage.tsx
@@ -1,0 +1,5 @@
+const BoardDetailPage = () => {
+  return <div>BoardDetailPage</div>;
+};
+
+export default BoardDetailPage;

--- a/src/pages/community/board/BoardDetailPage.tsx
+++ b/src/pages/community/board/BoardDetailPage.tsx
@@ -1,5 +1,49 @@
+import { useParams } from "react-router-dom";
+import { useGetBoardDetail } from "@/hooks/board/useGetBoardDetail";
+import { useState } from "react";
+import { BoardDetailHeader } from "@/components/\bcommunity/board/boardDetails/BoardDetailHeader";
+import { BoardDetailImages } from "@/components/\bcommunity/board/boardDetails/BoardDetailImages";
+import { BoardDetailContent } from "@/components/\bcommunity/board/boardDetails/BoardDetailContent";
+import { BoardComments } from "@/components/\bcommunity/board/boardDetails/BoardComments";
+import { CommentInputBar } from "@/components/\bcommunity/board/boardDetails/CommentInputBar";
+import { MessageSquare, ThumbsUp } from "lucide-react";
+
 const BoardDetailPage = () => {
-  return <div>BoardDetailPage</div>;
+  const { boardId } = useParams();
+  const { data, isLoading } = useGetBoardDetail(boardId!);
+
+  const [comment, setComment] = useState("");
+
+  if (isLoading || !data) return <div />;
+
+  const { board } = data;
+
+  const handleSubmit = () => {
+    console.log("댓글 등록:", comment);
+  };
+
+  return (
+    <div className='p-4 pb-20'>
+      <BoardDetailHeader board={board} />
+      <BoardDetailImages images={board.images} />
+      <BoardDetailContent board={board} />
+
+      <div className='flex items-center gap-4 mt-6 text-gray-500'>
+        <div className='flex items-center gap-1'>
+          <ThumbsUp size={18} />
+          <span>4</span>
+        </div>
+        <div className='flex items-center gap-1'>
+          <MessageSquare size={18} />
+          <span>{board.comments.length}</span>
+        </div>
+      </div>
+
+      <BoardComments comments={board.comments} />
+
+      <CommentInputBar comment={comment} onChange={setComment} onSubmit={handleSubmit} />
+    </div>
+  );
 };
 
 export default BoardDetailPage;

--- a/src/pages/community/board/CommunityBoardPage.tsx
+++ b/src/pages/community/board/CommunityBoardPage.tsx
@@ -1,0 +1,29 @@
+import { useState } from "react";
+import { BoardHeader } from "@/components/\bcommunity/board/boardList/BoardHeader";
+import { BoardList } from "@/components/\bcommunity/board/boardList/BoardList";
+import type { BoardType } from "@/types/board";
+import { GotoPostBtn } from "@/components/\bcommunity/board/boardList/GotoPostBtn";
+
+const CommunityBoardPage = () => {
+  const [sort, setSort] = useState<"popular" | "latest">("latest");
+  const [boardType, setBoardType] = useState<BoardType | undefined>(undefined);
+  const [keyword, setKeyword] = useState("");
+
+  return (
+    <div className='relative'>
+      <BoardHeader
+        sort={sort}
+        boardType={boardType}
+        onChangeSort={setSort}
+        onChangeBoardType={setBoardType}
+        onSearch={setKeyword}
+      />
+      <div className='px-3 py-2'>
+        <BoardList boardType={boardType} sort={sort} keyword={keyword} />
+        <GotoPostBtn />
+      </div>
+    </div>
+  );
+};
+
+export default CommunityBoardPage;

--- a/src/pages/community/board/CommunityPostPage.tsx
+++ b/src/pages/community/board/CommunityPostPage.tsx
@@ -1,5 +1,84 @@
+import { useState } from "react";
+import { Input } from "@/components/ui/input";
+import { fileToBase64 } from "@/utils/fileToBase64";
+import type { BoardType, BoardPostRequest } from "@/types/board";
+import { usePostBoard } from "@/hooks/board/usePostBoard";
+import { BoardTypeSelect } from "@/components/\bcommunity/board/boardPost/BoardTypeSelect";
+import { PhotoUploader } from "@/components/\bcommunity/board/boardPost/PhotoUploader";
+
 const CommunityPostPage = () => {
-  return <div>CommunityPostPage</div>;
+  const [title, setTitle] = useState("");
+  const [boardType, setBoardType] = useState<BoardType>("FREE");
+  const [content, setContent] = useState("");
+  const [images, setImages] = useState<string[]>([]);
+
+  const { mutate: postBoard, isPending } = usePostBoard();
+
+  const handleAddImage = async (file: File) => {
+    const base64 = await fileToBase64(file);
+    setImages((prev) => [...prev, base64]);
+  };
+
+  const handleRemoveImage = (index: number) => {
+    setImages((prev) => prev.filter((_, i) => i !== index));
+  };
+
+  const handleSubmit = () => {
+    const payload: BoardPostRequest = {
+      title,
+      content,
+      boardType,
+      images,
+    };
+
+    postBoard(payload, {
+      onSuccess: () => {
+        alert("게시글이 등록되었습니다.");
+        setTitle("");
+        setContent("");
+        setImages([]);
+      },
+      onError: () => {
+        alert("등록 중 오류가 발생했습니다.");
+      },
+    });
+  };
+
+  const isDisabled = isPending || title.trim() === "" || content.trim() === "";
+
+  return (
+    <div className='p-4 max-w-[430px] mx-auto pb-24'>
+      <div className='flex items-center justify-between'>
+        <Input
+          placeholder='제목을 입력해 주세요'
+          className='border-none shadow-none text-lg px-0 py-0'
+          value={title}
+          onChange={(e) => setTitle(e.target.value)}
+        />
+
+        <BoardTypeSelect value={boardType} onChange={setBoardType} />
+      </div>
+
+      <div className='border-b my-3' />
+
+      <textarea
+        placeholder='내용을 입력해 주세요'
+        className='border-none shadow-none resize-none px-0'
+        value={content}
+        onChange={(e) => setContent(e.target.value)}
+      />
+
+      <PhotoUploader images={images} onAdd={handleAddImage} onRemove={handleRemoveImage} />
+
+      <button
+        disabled={isDisabled}
+        onClick={handleSubmit}
+        className='mt-10 w-full py-3 bg-black text-white rounded-xl disabled:bg-gray-300 disabled:text-gray-500 disabled:cursor-not-allowed'
+      >
+        {isPending ? "등록 중..." : "등록하기"}
+      </button>
+    </div>
+  );
 };
 
 export default CommunityPostPage;

--- a/src/pages/community/board/CommunityPostPage.tsx
+++ b/src/pages/community/board/CommunityPostPage.tsx
@@ -1,0 +1,5 @@
+const CommunityPostPage = () => {
+  return <div>CommunityPostPage</div>;
+};
+
+export default CommunityPostPage;

--- a/src/pages/index.ts
+++ b/src/pages/index.ts
@@ -1,4 +1,3 @@
-import CommunityPage from "./community/CommunityPage";
 import NotFound from "./NotFound";
 import EcoReceiptPage from "./eco-receipt/EcoReceiptPage";
 import HomePage from "./home/HomePage";
@@ -16,12 +15,15 @@ import SignupEmailPage from "./signup/SignupEmailPage";
 import TicketPage from "./ticket/TicketPage";
 import SignupTermsPage from "./signup/SignupTermsPage";
 import SignupCompletePage from "./signup/SignupCompletePage";
+import CommunityBoardPage from "./community/board/CommunityBoardPage";
+import CommunityExchange from "./community/CommunityExchangePage";
+import CommunityPostPage from "./community/board/CommunityPostPage";
+import BoardDetailPage from "./community/board/BoardDetailPage";
 
 export {
   NotFound,
   HomePage,
   EcoReceiptPage,
-  CommunityPage,
   TicketPage,
   PartyListPage,
   PartyDetailPage,
@@ -36,4 +38,8 @@ export {
   SignupEmailPage,
   SignupTermsPage,
   SignupCompletePage,
+  CommunityBoardPage,
+  CommunityExchange,
+  CommunityPostPage,
+  BoardDetailPage,
 };

--- a/src/routes/userRoutes.tsx
+++ b/src/routes/userRoutes.tsx
@@ -1,6 +1,5 @@
 import RootLayout from "@/layouts/RootLayout";
 import {
-  CommunityPage,
   EcoReceiptPage,
   HomePage,
   MyPage,
@@ -17,6 +16,10 @@ import {
   SignupEmailPage,
   SignupTermsPage,
   TicketPage,
+  CommunityBoardPage,
+  CommunityExchange,
+  CommunityPostPage,
+  BoardDetailPage,
 } from "@/pages";
 import type { RouteObject } from "react-router-dom";
 
@@ -57,7 +60,16 @@ const userRoutes: RouteObject = {
     { path: "eco-receipt", element: <EcoReceiptPage /> }, // /eco-receipt
 
     // 커뮤니티
-    { path: "community", element: <CommunityPage /> }, // /community
+    {
+      path: "community",
+      children: [
+        { path: "board", element: <CommunityBoardPage /> },
+        { path: "board/:boardId", element: <BoardDetailPage /> },
+        { path: "board/post", element: <CommunityPostPage /> },
+
+        { path: "exchange", element: <CommunityExchange /> },
+      ],
+    }, // /community
 
     // QR 및 티켓
     {

--- a/src/types/board.ts
+++ b/src/types/board.ts
@@ -32,3 +32,11 @@ export interface BoardListResponse {
   nextCursor: string | null;
   hasNext: boolean;
 }
+
+// Board Post
+export interface BoardPostRequest {
+  title: string;
+  content: string;
+  boardType: BoardType;
+  images: string[];
+}

--- a/src/types/board.ts
+++ b/src/types/board.ts
@@ -1,0 +1,34 @@
+export type BoardType = "FREE" | "QNA" | "INFO";
+
+export interface BoardQuery {
+  boardType?: BoardType;
+  size?: number;
+  cursor?: string;
+}
+
+export interface Comment {
+  id: string;
+  content: string;
+  creatorId: string;
+  creatorNickname: string;
+  createdAt: string;
+}
+
+export interface BoardItem {
+  id: string;
+  title: string;
+  content: string;
+  updatedAt: string;
+  creatorNickname: string;
+  creatorId: string;
+  boardType: BoardType;
+  images: string[];
+  comments: Comment[];
+  createdAt: string;
+}
+
+export interface BoardListResponse {
+  items: BoardItem[];
+  nextCursor: string | null;
+  hasNext: boolean;
+}

--- a/src/types/boardDetail.ts
+++ b/src/types/boardDetail.ts
@@ -1,0 +1,25 @@
+export interface CommentItem {
+  id: string;
+  content: string;
+  creatorId: string;
+  creatorNickname: string;
+  createdAt: string;
+}
+
+export interface BoardDetail {
+  id: string;
+  title: string;
+  content: string;
+  updatedAt: string;
+  creatorNickname: string;
+  creatorId: string;
+  boardType: "FREE" | "QNA" | "INFO";
+  images: string[];
+  comments: CommentItem[];
+  createdAt: string;
+}
+
+export interface BoardDetailResponse {
+  isCreator: boolean;
+  board: BoardDetail;
+}

--- a/src/utils/fileToBase64.ts
+++ b/src/utils/fileToBase64.ts
@@ -1,0 +1,10 @@
+// 백엔드 서버 배포 전 이미지 파일 처리를 위한 임시 함수
+
+export const fileToBase64 = (file: File): Promise<string> => {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onloadend = () => resolve(reader.result as string);
+    reader.onerror = reject;
+    reader.readAsDataURL(file);
+  });
+};


### PR DESCRIPTION
## 🚀 관련 이슈

- close #11

## 🔑 주요 변경사항

### **1) 게시판 목록 기능 구현**
- 자유 / 정보공유 / FAQ 카테고리 필터링 기능 구현
- 검색어 입력 UI 구성  
  → 검색 쿼리는 백엔드 추가 후 연동 예정
- 정렬 옵션(최신순 / 인기순) UI 구성  
  → 정렬 기능도 백엔드 추가 후 연동 예정
- 게시글 리스트 UI 구성(썸네일, 제목, 내용 일부, 작성자, 날짜)

**현재 목록 API의 부족한 부분**
- 좋아요 수 없음  
- 댓글 수 없음  
→ 백엔드에서 목요일에 추가 예정이며, 추가되면 바로 반영할 계획



### **2) 게시글 상세 페이지 구현**
- 상세 조회 API 연동 완료 (`/api/board/{boardId}?boardId={boardId}`)
- 제목, 내용, 작성자명, 작성일, 이미지 렌더링
- 댓글 리스트 출력
- 하단 고정 댓글 입력창 UI 구현
- Lucide 아이콘 기반으로 전체 아이콘 적용

**상세 API 부족한 부분**
- 프로필 이미지 없음 → 기본 아이콘으로 대체
- 좋아요 수 없음
- 댓글 수 없음  
→ 백엔드 수정 후 반영 예정

**API 경로 이슈**
- 현재 `/api/board/{boardId}` + query param 구조  
→ 필요없는 구조이며, 백엔드에서 수정 예정  
→ 수정되면 프론트도 경로 수정 적용 예정



### **3) 게시글 작성 기능 구현**
- 제목 입력
- 내용 입력
- 게시판 타입 선택 (DropdownMenu 적용)
- 이미지 업로드 기능 구현 (파일 → base64 변환 후 저장)
- 업로드 이미지 썸네일 + 개별 삭제 기능 구현
- 등록하기 버튼 disabled 처리  
  (제목/내용 미입력, 로딩 상태일 때 비활성화 → 이것도 디자인 피그마랑 달라서 수정 예정)
- POST `/api/board/create` 연동 완료

**디자인 관련**
- 현재 기본 틀만 적용된 상태  
→ 상세 / 작성 페이지는 추후 디자인 디테일 다듬을 예정



### **4) HeaderConfig 구조 적용 준비**
- 현재 공통 헤더 적용 중
- 추후 페이지별 헤더 분리 예정
  - 목록: "자유게시판" 텍스트 헤더
  - 상세: 뒤로가기 + 더보기 버튼
  - 작성: 닫기 + 등록 버튼

→ 26일까지 페이지별 헤더 적용 완료 예정

## ↗️ 개선 사항

### **백엔드에서 목요일에 수정해주는 항목**
- 목록 API에  
  - `likeCount`  
  - `commentCount`  
  추가 예정
- 검색 기능 추가(검색어)
- 정렬 옵션(최신순, 인기순) 적용 가능한 쿼리 추가
- 상세 응답에  
  - `profileImage`  
  - `likeCount`  
  - `commentCount`  
  포함 예정
- 상세 API 경로(`/api/board/{boardId}`) REST 표준으로 수정 예정  
  → 프론트도 해당 변경에 맞춰 적용 예정

---

## 정리: 26일까지 작업 예정 항목
- 게시글 상세 페이지 디자인 디테일 작업
- 게시글 작성 페이지 디자인 디테일 작업
- 댓글 작성 기능 구현 (POST)
- 댓글 삭제 및 수정 기능
- 좋아요 기능 및 UI 상태 관리
- HeaderConfig 페이지별 적용
- 백엔드 스펙 전체 반영  
  (검색, 정렬, 좋아요 수, 댓글 수, 프로필 이미지 등)
