### PR TITLE
feat: Implement apply list page

### DIFF
--- a/src/components/party/partyApplyList/ApplyCard.tsx
+++ b/src/components/party/partyApplyList/ApplyCard.tsx
@@ -1,0 +1,102 @@
+import defaultThumbnail from "@/assets/images/default.png";
+import { ChevronRight } from "lucide-react";
+import type { PartyParticipantResponse, HostApplicationResponse } from "@/types/apply";
+import { STATUS_MAP } from "@/types/apply";
+import { InfoRow } from "./InfoRow";
+
+interface ApplyCardProps {
+  type: "participate" | "host";
+  data: PartyParticipantResponse | HostApplicationResponse;
+  onClick?: () => void;
+}
+
+// TODO: 중복 사용이 많아 분리하기
+// 날짜 포맷 유틸리티 함수
+const formatDate = (dateString: string) => {
+  const date = new Date(dateString);
+  return date.toLocaleDateString("ko-KR", {
+    year: "numeric",
+    month: "long",
+    day: "numeric",
+  });
+};
+
+const formatDateTime = (dateString: string) => {
+  const date = new Date(dateString);
+  return date.toLocaleDateString("ko-KR", {
+    year: "numeric",
+    month: "long",
+    day: "numeric",
+    hour: "numeric",
+  });
+};
+
+// 파티 참여 카드
+const ParticipateCard = ({
+  data,
+  onClick,
+}: {
+  data: PartyParticipantResponse;
+  onClick?: () => void;
+}) => {
+  const thumbnail = data.clothingItems[0]?.imageUrls[0] || defaultThumbnail;
+  const partyTitle = data.partyTitle || "파티 정보 없음";
+  const partyAddress = data.partyAddress || "정보 없음";
+
+  return (
+    <div className='px-5 py-4 cursor-pointer' onClick={onClick}>
+      <div className='flex justify-between items-center mb-4'>
+        <h3>{partyTitle}</h3>
+        <ChevronRight className='w-4 h-4 text-[#939396]' />
+      </div>
+
+      <div className='flex gap-4'>
+        <div className='w-22 h-22 shrink-0 overflow-hidden rounded-lg bg-gray-100'>
+          <img src={thumbnail} alt={partyTitle} className='w-full h-full object-cover' />
+        </div>
+
+        <div className='flex-1 flex flex-col gap-2 text-sm'>
+          <InfoRow label='날짜' value={formatDateTime(data.attendanceDate)} />
+          <InfoRow label='장소' value={partyAddress} />
+          <InfoRow label='교환의류' value={`${data.clothingItems.length}벌`} />
+          <InfoRow
+            label='상태'
+            value={STATUS_MAP[data.status]}
+            isCancelled={data.status === "CANCELLED"}
+          />
+        </div>
+      </div>
+    </div>
+  );
+};
+
+// 파티 주최 카드
+const HostCard = ({ data, onClick }: { data: HostApplicationResponse; onClick?: () => void }) => {
+  return (
+    <div className='px-5 py-4 cursor-pointer' onClick={onClick}>
+      <div className='flex justify-between items-center mb-4'>
+        <h3>{data.partyTitle}</h3>
+        <ChevronRight className='w-4 h-4 text-[#939396]' />
+      </div>
+
+      <div className='flex flex-col gap-2 text-sm'>
+        <InfoRow label='날짜' value={formatDate(data.desiredDate)} />
+        <InfoRow label='장소' value={data.address} />
+        <InfoRow label='참여자' value={`${data.maxAttendeeCnt}명`} />
+        <InfoRow label='교환의류' value={`${data.maxChangeCnt}벌`} />
+        <InfoRow
+          label='상태'
+          value={STATUS_MAP[data.status]}
+          isCancelled={data.status === "CANCELLED"}
+        />
+      </div>
+    </div>
+  );
+};
+
+export const ApplyCard = ({ type, data, onClick }: ApplyCardProps) => {
+  if (type === "participate") {
+    return <ParticipateCard data={data as PartyParticipantResponse} onClick={onClick} />;
+  }
+  return <HostCard data={data as HostApplicationResponse} onClick={onClick} />;
+};

--- a/src/components/party/partyApplyList/ApplyCard.tsx
+++ b/src/components/party/partyApplyList/ApplyCard.tsx
@@ -3,33 +3,13 @@ import { ChevronRight } from "lucide-react";
 import type { PartyParticipantResponse, HostApplicationResponse } from "@/types/apply";
 import { STATUS_MAP } from "@/types/apply";
 import { InfoRow } from "./InfoRow";
+import { formatDateKR, formatDateTimeKR } from "@/utils/formatDate.ts";
 
 interface ApplyCardProps {
   type: "participate" | "host";
   data: PartyParticipantResponse | HostApplicationResponse;
   onClick?: () => void;
 }
-
-// TODO: 중복 사용이 많아 분리하기
-// 날짜 포맷 유틸리티 함수
-const formatDate = (dateString: string) => {
-  const date = new Date(dateString);
-  return date.toLocaleDateString("ko-KR", {
-    year: "numeric",
-    month: "long",
-    day: "numeric",
-  });
-};
-
-const formatDateTime = (dateString: string) => {
-  const date = new Date(dateString);
-  return date.toLocaleDateString("ko-KR", {
-    year: "numeric",
-    month: "long",
-    day: "numeric",
-    hour: "numeric",
-  });
-};
 
 // 파티 참여 카드
 const ParticipateCard = ({
@@ -56,7 +36,7 @@ const ParticipateCard = ({
         </div>
 
         <div className='flex-1 flex flex-col gap-2 text-sm'>
-          <InfoRow label='날짜' value={formatDateTime(data.attendanceDate)} />
+          <InfoRow label='날짜' value={formatDateTimeKR(data.attendanceDate)} />
           <InfoRow label='장소' value={partyAddress} />
           <InfoRow label='교환의류' value={`${data.clothingItems.length}벌`} />
           <InfoRow
@@ -80,7 +60,7 @@ const HostCard = ({ data, onClick }: { data: HostApplicationResponse; onClick?: 
       </div>
 
       <div className='flex flex-col gap-2 text-sm'>
-        <InfoRow label='날짜' value={formatDate(data.desiredDate)} />
+        <InfoRow label='날짜' value={formatDateKR(data.desiredDate)} />
         <InfoRow label='장소' value={data.address} />
         <InfoRow label='참여자' value={`${data.maxAttendeeCnt}명`} />
         <InfoRow label='교환의류' value={`${data.maxChangeCnt}벌`} />

--- a/src/components/party/partyApplyList/ApplyHeader.tsx
+++ b/src/components/party/partyApplyList/ApplyHeader.tsx
@@ -1,0 +1,37 @@
+interface ApplyHeaderProps {
+  currentTab: "participate" | "host";
+  setCurrentTab: (tab: "participate" | "host") => void;
+}
+
+export const ApplyHeader = ({ currentTab, setCurrentTab }: ApplyHeaderProps) => {
+  const tabs = [
+    { id: "participate" as const, label: "파티 참여" },
+    { id: "host" as const, label: "파티 주최" },
+  ];
+
+  const getTabStyle = (tab: "participate" | "host") => {
+    const isActive = currentTab === tab;
+    const baseStyle = "w-1/2 text-center cursor-pointer pb-2 transition-colors border-b";
+
+    if (!isActive) {
+      return `${baseStyle} border-[#E0E2E4]`;
+    }
+
+    const borderColor =
+      tab === "participate"
+        ? "border-[var(--color-mint-light)] text-[var(--color-mint-light)]"
+        : "border-[var(--color-purple-light)] text-[var(--color-purple-light)]";
+
+    return `${baseStyle} font-bold ${borderColor}`;
+  };
+
+  return (
+    <div className='sticky top-0 flex justify-between pt-6 bg-white z-10'>
+      {tabs.map((tab) => (
+        <div key={tab.id} onClick={() => setCurrentTab(tab.id)} className={getTabStyle(tab.id)}>
+          {tab.label}
+        </div>
+      ))}
+    </div>
+  );
+};

--- a/src/components/party/partyApplyList/ApplyList.tsx
+++ b/src/components/party/partyApplyList/ApplyList.tsx
@@ -1,0 +1,31 @@
+import { ApplyCard } from "./ApplyCard";
+import type { PartyParticipantResponse, HostApplicationResponse } from "@/types/apply";
+
+interface ApplyListProps {
+  type: "participate" | "host";
+  data?: PartyParticipantResponse[] | HostApplicationResponse[];
+  onCardClick?: (id: string) => void;
+}
+
+export const ApplyList = ({ type, data = [], onCardClick }: ApplyListProps) => {
+  if (data.length === 0) {
+    return (
+        <div className='flex flex-col items-center justify-center py-20 text-[#939396]'>
+          <p>{type === "participate" ? "참여" : "주최"} 신청 내역이 없습니다</p>
+        </div>
+    );
+  }
+
+  return (
+      <div className='flex flex-col'>
+        {data.map((item) => (
+            <ApplyCard
+                key={item.id}
+                type={type}
+                data={item}
+                onClick={() => onCardClick?.(item.id)}
+            />
+        ))}
+      </div>
+  );
+};

--- a/src/components/party/partyApplyList/InfoRow.tsx
+++ b/src/components/party/partyApplyList/InfoRow.tsx
@@ -1,0 +1,14 @@
+interface InfoRowProps {
+  label: string;
+  value: string | number;
+  isCancelled?: boolean;
+}
+
+export const InfoRow = ({ label, value, isCancelled = false }: InfoRowProps) => (
+  <div className='flex items-baseline'>
+    <span className='w-[70px] shrink-0 text-[#939396] text-sm'>{label}</span>
+    <span className={`font-medium ${isCancelled ? "text-[#F23F3F]" : "text-[#222222]"}`}>
+      {value}
+    </span>
+  </div>
+);

--- a/src/pages/party/ApplyListPage.tsx
+++ b/src/pages/party/ApplyListPage.tsx
@@ -1,9 +1,70 @@
+import { ApplyHeader } from "@/components/party/partyApplyList/ApplyHeader.tsx";
+import { ApplyList } from "@/components/party/partyApplyList/ApplyList.tsx";
+import { FilterHeader } from "@/components/common/FilterHeader.tsx";
+import { useNavigate, useSearchParams } from "react-router-dom";
+
+import { dummyParticipateData, dummyHostData } from "@/utils/apply/dummy.ts";
+
+const statusTabs: { label: string; value: "apply" | "canceled" }[] = [
+  { label: "신청", value: "apply" },
+  { label: "취소", value: "canceled" },
+];
+
 export default function ApplyListPage() {
+  const navigate = useNavigate();
+  const [searchParams, setSearchParams] = useSearchParams();
+
+  const currentTab = (searchParams.get("tab") as "participate" | "host") || "participate";
+  const currentStatus = (searchParams.get("status") as "apply" | "canceled") || "apply";
+
+  const setCurrentTab = (tab: "participate" | "host") => {
+    setSearchParams({ tab, status: "apply" });
+  };
+
+  const setCurrentStatus = (status: "apply" | "canceled") => {
+    setSearchParams({ tab: currentTab, status });
+  };
+
+  // TODO: API 연결
+  const participateData = dummyParticipateData;
+  const hostData = dummyHostData;
+
+  const filterTheme = currentTab === "participate" ? "mint" : "purple";
+
+  const getFilteredData = () => {
+    if (currentTab === "participate") {
+      return (
+        participateData?.filter((item) =>
+          currentStatus === "apply" ? item.status !== "CANCELLED" : item.status === "CANCELLED"
+        ) || []
+      );
+    }
+    return (
+      hostData?.filter((item) =>
+        currentStatus === "apply" ? item.status !== "CANCELLED" : item.status === "CANCELLED"
+      ) || []
+    );
+  };
+
+  const filteredData = getFilteredData();
+
+  const handleCardClick = (id: string) => {
+    navigate(`/party/apply/${id}`);
+  };
+
   return (
-    <div className='relative min-h-screen'>
+    <div className='flex flex-col h-full'>
       {/* Header(Menu Tab) */}
-      <div>파티 참여/파티 주최 선택</div>
+      <ApplyHeader currentTab={currentTab} setCurrentTab={setCurrentTab} />
+      {/* filter */}
+      <FilterHeader
+        onChange={(v) => v && setCurrentStatus(v)}
+        tabs={statusTabs}
+        value={currentStatus}
+        theme={filterTheme}
+      />
       {/* 리스트 */}
+      <ApplyList type={currentTab} data={filteredData} onCardClick={handleCardClick} />
     </div>
   );
 }

--- a/src/pages/party/ApplyListPage.tsx
+++ b/src/pages/party/ApplyListPage.tsx
@@ -5,6 +5,9 @@ import { useNavigate, useSearchParams } from "react-router-dom";
 
 import { dummyParticipateData, dummyHostData } from "@/utils/apply/dummy.ts";
 
+export type ApplyStatus = "apply" | "canceled";
+export type ApplyTab = "participate" | "host";
+
 const statusTabs: { label: string; value: "apply" | "canceled" }[] = [
   { label: "신청", value: "apply" },
   { label: "취소", value: "canceled" },
@@ -14,14 +17,14 @@ export default function ApplyListPage() {
   const navigate = useNavigate();
   const [searchParams, setSearchParams] = useSearchParams();
 
-  const currentTab = (searchParams.get("tab") as "participate" | "host") || "participate";
-  const currentStatus = (searchParams.get("status") as "apply" | "canceled") || "apply";
+  const currentTab = (searchParams.get("tab") as ApplyTab) || "participate";
+  const currentStatus = (searchParams.get("status") as ApplyStatus) || "apply";
 
-  const setCurrentTab = (tab: "participate" | "host") => {
+  const setCurrentTab = (tab: ApplyTab) => {
     setSearchParams({ tab, status: "apply" });
   };
 
-  const setCurrentStatus = (status: "apply" | "canceled") => {
+  const setCurrentStatus = (status: ApplyStatus) => {
     setSearchParams({ tab: currentTab, status });
   };
 

--- a/src/routes/userRoutes.tsx
+++ b/src/routes/userRoutes.tsx
@@ -172,6 +172,7 @@ const userRoutes: RouteObject = {
       element: <TicketPage />,
       handle: { header: { type: "base" } },
     },
+
     // 파티 참여
     {
       path: "party",

--- a/src/types/apply.ts
+++ b/src/types/apply.ts
@@ -4,6 +4,14 @@
 
 // 신청 상태 타입
 export type ParticipantStatus = "PENDING" | "APPROVED" | "REJECTED" | "CANCELLED";
+export type HostApplicationStatus = "PENDING" | "APPROVED" | "REJECTED" | "CANCELLED";
+
+export const STATUS_MAP: Record<ParticipantStatus | HostApplicationStatus, string> = {
+  PENDING: "승인대기",
+  APPROVED: "승인완료",
+  REJECTED: "반려",
+  CANCELLED: "취소",
+};
 
 // Request DTO
 export interface ClothingItemRequest {
@@ -47,4 +55,44 @@ export interface PartyParticipantResponse {
 
   qrCode: string | null;
   qrExpiresAt: string | null;
+
+  // TODO: 백엔드 dto 추가 요청
+  partyTitle?: string;
+  partyAddress?: string;
+}
+
+export interface HostApplicationResponse {
+  id: string;
+  isGroup: boolean;
+  groupName: string;
+  userId: string;
+
+  name: string;
+  phone: string;
+  email: string;
+
+  openAt: string;
+  closeAt: string;
+  address: string;
+  addressDetail: string;
+
+  maxChangeCnt: number;
+  maxAttendeeCnt: number;
+
+  partyTitle: string;
+  partyDescription: string;
+  deliverAddress: string;
+  deliverAddressDetail: string;
+  desiredDate: string;
+
+  taxReceipt: boolean;
+  taxEmail: string;
+
+  status: HostApplicationStatus;
+  processMemo: string;
+  appliedAt: string;
+  processedAt: string;
+
+  xmap: number;
+  ymap: number;
 }

--- a/src/utils/apply/dummy.ts
+++ b/src/utils/apply/dummy.ts
@@ -1,0 +1,179 @@
+import type { PartyParticipantResponse, HostApplicationResponse } from "@/types/apply";
+
+// PartyParticipantResponse의 상태 타입: "PENDING" | "APPROVED" | "REJECTED" | "CANCELLED"
+export const dummyParticipateData: PartyParticipantResponse[] = [
+  {
+    id: "p1",
+    partyId: "party-001",
+    userId: "user-001",
+
+    name: "홍길동",
+    phone: "010-1111-2222",
+    email: "hong@example.com",
+
+    clothingItems: [
+      {
+        clothingNumber: "CL-1001",
+        mainCategory: "상의",
+        subCategory: "자켓",
+        description: "깔끔한 블랙 자켓",
+        imageUrls: [],
+      },
+    ],
+
+    attendanceDate: "2025-10-03T14:00:00",
+    status: "PENDING",
+    appliedAt: "2025-01-20",
+    processedAt: null,
+
+    qrCode: null,
+    qrExpiresAt: null,
+
+    // 파티 정보
+    partyTitle: "광진 능동 파티",
+    partyAddress: "서울특별시 광진구 군자동",
+  },
+  {
+    id: "p2",
+    partyId: "party-002",
+    userId: "user-002",
+
+    name: "김철수",
+    phone: "010-2222-3333",
+    email: "kim@example.com",
+
+    clothingItems: [
+      {
+        clothingNumber: "CL-2001",
+        mainCategory: "하의",
+        subCategory: "바지",
+        description: "스트레이트 핏 청바지",
+        imageUrls: [],
+      },
+    ],
+
+    attendanceDate: "2025-10-03T14:00:00",
+    status: "CANCELLED",
+    appliedAt: "2025-02-15",
+    processedAt: "2025-02-18",
+
+    qrCode: null,
+    qrExpiresAt: null,
+
+    // 파티 정보
+    partyTitle: "광진 능동 파티",
+    partyAddress: "서울특별시 광진구 군자동",
+  },
+  {
+    id: "p3",
+    partyId: "party-003",
+    userId: "user-003",
+
+    name: "이영희",
+    phone: "010-3333-4444",
+    email: "lee@example.com",
+
+    clothingItems: [
+      {
+        clothingNumber: "CL-3001",
+        mainCategory: "드레스",
+        subCategory: "원피스",
+        description: "봄 시즌 화이트 원피스",
+        imageUrls: [],
+      },
+      {
+        clothingNumber: "CL-3002",
+        mainCategory: "기타",
+        subCategory: "가방",
+        description: "여성 미니백",
+        imageUrls: [],
+      },
+    ],
+
+    attendanceDate: "2025-10-03T14:00:00",
+    status: "PENDING",
+    appliedAt: "2025-03-22",
+    processedAt: null,
+
+    qrCode: null,
+    qrExpiresAt: null,
+
+    // 파티 정보
+    partyTitle: "광진 능동 파티",
+    partyAddress: "서울특별시 광진구 군자동",
+  },
+];
+
+// HostApplicationResponse의 상태 타입: "PENDING" | "APPROVED" | "REJECTED" | "CANCELLED"
+export const dummyHostData: HostApplicationResponse[] = [
+  {
+    id: "h1",
+    isGroup: false,
+    groupName: "",
+    userId: "user-001",
+
+    name: "홍길동",
+    phone: "010-1111-2222",
+    email: "hong@example.com",
+
+    openAt: "2025-03-01",
+    closeAt: "2025-03-05",
+    address: "서울특별시 광진구 군자동",
+    addressDetail: "",
+
+    maxChangeCnt: 5,
+    maxAttendeeCnt: 30,
+
+    partyTitle: "광진 능동 파티",
+    partyDescription: "광진구에서 열리는 패션 교환 파티.",
+    deliverAddress: "서울 광진구 물류센터",
+    deliverAddressDetail: "2층 배송실",
+    desiredDate: "2025-10-03",
+
+    taxReceipt: false,
+    taxEmail: "",
+
+    status: "PENDING",
+    processMemo: "",
+    appliedAt: "2025-02-20",
+    processedAt: "",
+
+    xmap: 127.0276,
+    ymap: 37.4979,
+  },
+  {
+    id: "h2",
+    isGroup: true,
+    groupName: "패션모임",
+    userId: "user-002",
+
+    name: "김철수",
+    phone: "010-2222-3333",
+    email: "kim@example.com",
+
+    openAt: "2025-04-10",
+    closeAt: "2025-04-12",
+    address: "서울특별시 광진구 군자동",
+    addressDetail: "",
+
+    maxChangeCnt: 5,
+    maxAttendeeCnt: 30,
+
+    partyTitle: "광진 능동 파티",
+    partyDescription: "광진구에서 열리는 대규모 패션 교환 행사.",
+    deliverAddress: "서울 광진구 물류센터",
+    deliverAddressDetail: "1층 접수실",
+    desiredDate: "2025-10-03",
+
+    taxReceipt: true,
+    taxEmail: "kim-tax@example.com",
+
+    status: "CANCELLED",
+    processMemo: "",
+    appliedAt: "2025-03-10",
+    processedAt: "",
+
+    xmap: 126.9143,
+    ymap: 37.5481,
+  },
+];

--- a/src/utils/formatDate.ts
+++ b/src/utils/formatDate.ts
@@ -10,3 +10,22 @@ export const formatDate = (isoDate: string): string => {
 
   return `${year}.${month}.${day}`;
 };
+
+export const formatDateKR = (dateString: string) => {
+  const date = new Date(dateString);
+  return date.toLocaleDateString("ko-KR", {
+    year: "numeric",
+    month: "long",
+    day: "numeric",
+  });
+};
+
+export const formatDateTimeKR = (dateString: string) => {
+  const date = new Date(dateString);
+  return date.toLocaleDateString("ko-KR", {
+    year: "numeric",
+    month: "long",
+    day: "numeric",
+    hour: "numeric",
+  });
+};


### PR DESCRIPTION
### 🔍 작업 개요
- 파티 신청 내역(참여+주최) 페이지 UI 구현

### ✨ 주요 변경사항
<img width="816" height="1406" alt="image" src="https://github.com/user-attachments/assets/df9ac2e6-0e6e-44e8-8858-1fd1c25e57b1" />
<img width="818" height="1406" alt="image" src="https://github.com/user-attachments/assets/ad5d7f29-7571-4250-b185-83b9e859f10f" />

1. 파티 신청내역 페이지 및 컴포넌트 UI 구현
- `ApplyListPage.tsx`: 파티 신청내역 페이지 UI 구현
  - `ApplyHeader.tsx`: 참여 및 주최 탭 구분 컴포넌트

2. 타입 정의 추가
- `types/apply.ts`: PartyParticipantResponse, HostApplicationResponse 타입 정의 추가

## 📚 남은 일
- [x] api 연결
- PartyParticipantResponse에 없는 값이 있어 백엔드에 추가 요청함
- [x] 날짜 포맷 유틸리티 함수 분리
- 현재 중복 사용하는 날짜 포맷 유틸리티가 많아 분리 예정

close #28 