### PR TITLE
feat: 파티에서 티켓 사용 기능 구현

### DIFF
--- a/src/apis/admin/party/manage/patchTax.ts
+++ b/src/apis/admin/party/manage/patchTax.ts
@@ -1,15 +1,10 @@
 // import { axiosInstance } from "@/apis/axios-instance.ts";
 
-export const patchTax = async (
-  params: {
-    taxId: string;
-    name: string;
-  },
-) => {
+export const patchTax = async (_params: { taxId: string; name: string }) => {
   // const { data } = await axiosInstance.patch(
   //   "",
   //   // `/api/party/applications/admin/${applicationId}/delivery-status`,
-  //   params,
+  //   _params,
   // );
   // return data;
   return;

--- a/src/apis/inspection/getPartyClothingItems.ts
+++ b/src/apis/inspection/getPartyClothingItems.ts
@@ -1,0 +1,25 @@
+import { axiosInstance } from "@/apis/axios-instance";
+
+export interface PartyClothingItem {
+  clothingNumber: string;
+  category: string;
+  description: string;
+  imageUrls: string[];
+  donorUserId: string;
+}
+
+export const getPartyClothingItems = async (
+  partyId: string,
+  params?: { searchKeyword?: string }
+): Promise<PartyClothingItem[]> => {
+  const { data } = await axiosInstance.get<PartyClothingItem[]>(
+    `/api/inspection/available-clothes`,
+    {
+      params: {
+        partyId,
+        ...params,
+      },
+    }
+  );
+  return data;
+};

--- a/src/apis/inspection/useVoucher.ts
+++ b/src/apis/inspection/useVoucher.ts
@@ -1,0 +1,13 @@
+import { axiosInstance } from "@/apis/axios-instance";
+
+export interface UseVoucherParams {
+  voucherQrCode: string;
+  partyId: string;
+  takenClothingNumber?: string;
+}
+
+export const useVoucher = async (params: UseVoucherParams): Promise<void> => {
+  await axiosInstance.post("/api/inspection/vouchers/use", null, {
+    params,
+  });
+};

--- a/src/components/community/board/boardDetails/BoardDetailHeader.tsx
+++ b/src/components/community/board/boardDetails/BoardDetailHeader.tsx
@@ -7,7 +7,7 @@ interface Props {
 }
 
 export const BoardDetailHeader = ({ board }: Props) => {
-  const date = format(new Date(board.createdAt), "MM/dd HH:mm");
+  const date = board.createdAt ? format(new Date(board.createdAt), "MM/dd HH:mm") : "";
 
   return (
     <div className='flex items-start gap-3 mb-4'>

--- a/src/components/inspection-ticket/TicketScanView.tsx
+++ b/src/components/inspection-ticket/TicketScanView.tsx
@@ -1,0 +1,129 @@
+import { useState, useEffect, useRef, useCallback } from "react";
+import { Html5Qrcode } from "html5-qrcode";
+import { X } from "lucide-react";
+
+interface TicketScanViewProps {
+  partyId: string;
+  clothingNumber?: string; // 선택적: 의류 코드가 있으면 전달, 없으면 건너뛰기로 온 경우
+  onClose: () => void;
+  onScanSuccess: (qrCode: string) => void;
+}
+
+export const TicketScanView = ({ onClose, onScanSuccess }: TicketScanViewProps) => {
+  const [error, setError] = useState<string | null>(null);
+  const scannerRef = useRef<Html5Qrcode | null>(null);
+  const isMountedRef = useRef(true);
+  const scannerContainerId = "ticket-scanner-container";
+
+  // 스캐너 정지
+  const stopScanner = useCallback(async () => {
+    if (scannerRef.current) {
+      try {
+        const isScanning = scannerRef.current.isScanning;
+        if (isScanning) {
+          await scannerRef.current.stop();
+        }
+      } catch (err) {
+        console.error("스캐너 정지 실패:", err);
+      } finally {
+        scannerRef.current = null;
+      }
+    }
+  }, []);
+
+  // 스캐너 시작
+  const startScanner = useCallback(async () => {
+    // 이미 스캐너가 실행 중이면 먼저 정지
+    await stopScanner();
+
+    if (!isMountedRef.current) return;
+
+    try {
+      setError(null);
+
+      const html5QrCode = new Html5Qrcode(scannerContainerId);
+      scannerRef.current = html5QrCode;
+
+      const config = {
+        fps: 10,
+        qrbox: { width: 250, height: 250 },
+        aspectRatio: 1,
+      };
+
+      await html5QrCode.start(
+        { facingMode: "environment" },
+        config,
+        (decodedText) => {
+          if (!isMountedRef.current) return;
+          onScanSuccess(decodedText);
+          stopScanner();
+        },
+        () => {
+          // 에러는 무시 (스캔 중이므로)
+        }
+      );
+
+      if (isMountedRef.current) {
+        setError(null);
+      }
+    } catch (err: any) {
+      console.error("스캐너 시작 실패:", err);
+      if (isMountedRef.current) {
+        setError("카메라를 시작할 수 없습니다. 카메라 권한을 확인해주세요.");
+      }
+    }
+  }, [onScanSuccess, stopScanner, scannerContainerId]);
+
+  useEffect(() => {
+    isMountedRef.current = true;
+
+    // DOM이 준비된 후 스캐너 시작
+    const timer = setTimeout(() => {
+      startScanner();
+    }, 300);
+
+    return () => {
+      isMountedRef.current = false;
+      clearTimeout(timer);
+      stopScanner();
+    };
+  }, [startScanner, stopScanner]);
+
+  const handleClose = () => {
+    stopScanner();
+    onClose();
+  };
+
+  return (
+    <div className='fixed inset-0 z-50 bg-gray-900 flex flex-col'>
+      {/* 헤더 */}
+      <div className='flex justify-end p-4'>
+        <button
+          onClick={handleClose}
+          className='p-2 hover:bg-gray-800 rounded-full transition-colors'
+        >
+          <X size={24} className='text-white' />
+        </button>
+      </div>
+
+      {/* 스캔 영역 */}
+      <div className='flex-1 flex flex-col items-center justify-center px-4'>
+        <div className='w-full max-w-sm'>
+          {/* 스캔 가이드 박스 */}
+          <div className='relative w-full aspect-square bg-gray-800 rounded-lg overflow-hidden mb-4'>
+            <div id={scannerContainerId} className='w-full h-full' style={{ minHeight: "300px" }} />
+            {/* 가이드 프레임 */}
+            <div className='absolute inset-0 flex items-center justify-center pointer-events-none'>
+              <div className='w-64 h-64 border-2 border-white rounded-lg' />
+            </div>
+          </div>
+
+          {/* 안내 문구 */}
+          <p className='text-white text-center text-lg font-medium'>티켓을 스캔해 주세요</p>
+
+          {error && <p className='text-red-400 text-center text-sm mt-2'>{error}</p>}
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/src/hooks/admin/party/manage/usePatchTax.ts
+++ b/src/hooks/admin/party/manage/usePatchTax.ts
@@ -1,14 +1,16 @@
 import { AxiosError } from "axios";
 import { useMutation } from "@tanstack/react-query";
 import { queryClient } from "@/lib/queryClient.ts";
-import type {  TaxUpdateRequest } from "@/types/admin/party.ts";
+import type { TaxUpdateRequest } from "@/types/admin/party.ts";
 import { patchTax } from "@/apis/admin/party/manage/patchTax.ts";
-
 
 export const usePatchTax = () => {
   return useMutation({
     mutationKey: ["tax"],
     mutationFn: async ({ taxId, name }: TaxUpdateRequest) => {
+      if (!taxId || !name) {
+        throw new Error("taxId와 name은 필수입니다.");
+      }
       return await patchTax({ taxId, name });
     },
     onSuccess: () => {

--- a/src/hooks/common/useDebounce.ts
+++ b/src/hooks/common/useDebounce.ts
@@ -1,0 +1,17 @@
+import { useState, useEffect } from "react";
+
+export function useDebounce<T>(value: T, delay: number): T {
+  const [debouncedValue, setDebouncedValue] = useState<T>(value);
+
+  useEffect(() => {
+    const handler = setTimeout(() => {
+      setDebouncedValue(value);
+    }, delay);
+
+    return () => {
+      clearTimeout(handler);
+    };
+  }, [value, delay]);
+
+  return debouncedValue;
+}

--- a/src/hooks/common/useThrottle.ts
+++ b/src/hooks/common/useThrottle.ts
@@ -1,0 +1,35 @@
+import { useState, useEffect, useRef } from "react";
+
+export function useThrottle<T>(value: T, delay: number): T {
+  const [throttledValue, setThrottledValue] = useState<T>(value);
+  const lastRan = useRef<number>(Date.now());
+  const timeoutRef = useRef<NodeJS.Timeout | null>(null);
+
+  useEffect(() => {
+    const now = Date.now();
+    const timeSinceLastRun = now - lastRan.current;
+
+    if (timeSinceLastRun >= delay) {
+      // 지연 시간이 지났으면 즉시 업데이트
+      setThrottledValue(value);
+      lastRan.current = now;
+    } else {
+      // 아직 지연 시간이 안 지났으면 남은 시간만큼 대기
+      if (timeoutRef.current) {
+        clearTimeout(timeoutRef.current);
+      }
+      timeoutRef.current = setTimeout(() => {
+        setThrottledValue(value);
+        lastRan.current = Date.now();
+      }, delay - timeSinceLastRun);
+    }
+
+    return () => {
+      if (timeoutRef.current) {
+        clearTimeout(timeoutRef.current);
+      }
+    };
+  }, [value, delay]);
+
+  return throttledValue;
+}

--- a/src/hooks/inspection/useGetPartyClothingItems.ts
+++ b/src/hooks/inspection/useGetPartyClothingItems.ts
@@ -1,0 +1,16 @@
+import { useQuery } from "@tanstack/react-query";
+import {
+  getPartyClothingItems,
+  type PartyClothingItem,
+} from "@/apis/inspection/getPartyClothingItems";
+
+export const useGetPartyClothingItems = (partyId: string, params?: { searchKeyword?: string }) => {
+  // 검색어가 2자 이상일 때만 API 호출 (처음에는 아무것도 표시하지 않음)
+  const shouldFetch = !!partyId && !!params?.searchKeyword && params.searchKeyword.length >= 2;
+
+  return useQuery<PartyClothingItem[]>({
+    queryKey: ["partyClothingItems", partyId, params],
+    queryFn: () => getPartyClothingItems(partyId, params),
+    enabled: shouldFetch,
+  });
+};

--- a/src/hooks/inspection/useUseVoucher.ts
+++ b/src/hooks/inspection/useUseVoucher.ts
@@ -1,0 +1,9 @@
+import { useMutation } from "@tanstack/react-query";
+import { useVoucher, type UseVoucherParams } from "@/apis/inspection/useVoucher";
+
+export const useUseVoucher = () => {
+  return useMutation({
+    mutationKey: ["useVoucher"],
+    mutationFn: (params: UseVoucherParams) => useVoucher(params),
+  });
+};

--- a/src/layouts/components/header/HeaderBase.tsx
+++ b/src/layouts/components/header/HeaderBase.tsx
@@ -1,8 +1,9 @@
 import { useEffect, useState } from "react";
 import HeaderContainer from "./HeaderContainer";
-import { useLocation } from "react-router-dom";
+import { useLocation, useParams } from "react-router-dom";
 import { useMe } from "@/hooks/auth/useMe";
 import { useNavigate } from "react-router-dom";
+import { useGetParty } from "@/hooks/party/useGetParty";
 import { Back, Hamburger } from "@/components/common/header";
 
 interface HeaderProps {
@@ -22,9 +23,18 @@ export default function HeaderBase({
   const dummyTicket = 2;
   const dummyCo2 = 12.5;
   const location = useLocation();
+  const params = useParams();
   const { data } = useMe();
 
   const navigate = useNavigate();
+
+  // 파티 상세 페이지인 경우 파티 정보 가져오기
+  const isInspectionTicketPage =
+    location.pathname.startsWith("/inspection-ticket/") && params.partyId;
+  const { data: partyData } = useGetParty(isInspectionTicketPage ? params.partyId || "" : "");
+
+  // 실제 표시할 라벨 결정 (파티 페이지면 파티명, 아니면 기본 라벨)
+  const displayLabel = isInspectionTicketPage && partyData?.title ? partyData.title : label;
 
   useEffect(() => {
     setOpen(false);
@@ -38,7 +48,7 @@ export default function HeaderBase({
       <div className='flex justify-between gap-2 items-center'>
         {showBack && <Back onClick={() => (to ? navigate(to) : navigate(-1))} />}
 
-        {showLabel && label && <h2 className='text-start'>{label}</h2>}
+        {showLabel && displayLabel && <h2 className='text-start'>{displayLabel}</h2>}
       </div>
       <Hamburger
         open={open}

--- a/src/pages/community/exchange/ExchangeRequestPage.tsx
+++ b/src/pages/community/exchange/ExchangeRequestPage.tsx
@@ -45,12 +45,7 @@ const ExchangeRequestPage = () => {
     isError: isErrorVouchers,
     error: errorVouchers,
   } = useGetAvailableVouchers();
-  const {
-    data: baseAreas,
-    isLoading: isLoadingAreas,
-    isError: isErrorAreas,
-    error: errorAreas,
-  } = useGetBaseAreas();
+  const { isLoading: isLoadingAreas, isError: isErrorAreas, error: errorAreas } = useGetBaseAreas();
   const { mutate: postExchangeRequest, isPending } = usePostExchangeRequest();
 
   const isLoading = isLoadingVouchers || isLoadingAreas;

--- a/src/pages/impact/ImpactReceiptPage.tsx
+++ b/src/pages/impact/ImpactReceiptPage.tsx
@@ -4,7 +4,6 @@ interface DataPoint {
   label: string;
   value: number;
 }
-import { FilterHeader } from "@/components/common/FilterHeader";
 import SectionTitle from "@/components/community/exchange/requestApply/SectionTitle";
 import { SummaryCard } from "@/components/impact/SummaryCard";
 import { EnvironmentalMetrics } from "@/components/impact/EnvironmentalMetrics";

--- a/src/pages/index.ts
+++ b/src/pages/index.ts
@@ -28,6 +28,8 @@ import RequestInfoPage from "./community/exchange/RequestInfoPage";
 import ImpactReceiptPage from "./impact/ImpactReceiptPage";
 import SettingsPage from "@/pages/settings/SettingsPage";
 import UserProfilePage from "@/pages/settings/UserProfilePage.tsx";
+import InspectionTicketPage from "./inspection-ticket/InspectionTicketPage";
+import PartyClothingListPage from "./inspection-ticket/PartyClothingListPage";
 
 export {
   NotFound,
@@ -60,4 +62,6 @@ export {
   ImpactReceiptPage,
   SettingsPage,
   UserProfilePage,
+  InspectionTicketPage,
+  PartyClothingListPage,
 };

--- a/src/pages/inspection-ticket/InspectionTicketPage.tsx
+++ b/src/pages/inspection-ticket/InspectionTicketPage.tsx
@@ -1,0 +1,74 @@
+import { useNavigate } from "react-router-dom";
+import { useGetMyHostedParties } from "@/hooks/party/useGetParty";
+import { Button } from "@/components/ui/button";
+import StatusHandler from "@/components/common/StatusHandler";
+import { QrCode } from "lucide-react";
+import { format } from "date-fns";
+import { ko } from "date-fns/locale";
+
+export default function InspectionTicketPage() {
+  const navigate = useNavigate();
+
+  const {
+    data: hostedPartiesData,
+    isLoading,
+    isError,
+    error,
+  } = useGetMyHostedParties({ size: 100 });
+
+  const parties = hostedPartiesData?.pages.flatMap((page) => page.parties) ?? [];
+
+  const handleTicketScan = (partyId: string) => {
+    navigate(`/inspection-ticket/${partyId}`);
+  };
+
+  return (
+    <div className="flex flex-col h-full">
+      <StatusHandler isLoading={isLoading} isError={isError} error={error}>
+        {parties.length === 0 ? (
+          <div className="flex-1 flex flex-col items-center justify-center px-4">
+            <p className="text-gray-400 mb-4">주최한 파티가 없습니다.</p>
+            <Button
+              theme="purple"
+              onClick={() => navigate("/host")}
+              className="w-full max-w-sm"
+            >
+              파티 주최하기
+            </Button>
+          </div>
+        ) : (
+          <div className="flex-1 overflow-y-auto p-5">
+            <div className="flex flex-col gap-4">
+              {parties.map((party) => {
+                const formattedDate = party.openAt
+                  ? format(new Date(party.openAt), "yyyy년 M월 d일", { locale: ko })
+                  : "";
+
+                return (
+                  <div
+                    key={party.id}
+                    className="flex items-center justify-between p-4 rounded-lg bg-[var(--color-purple-dark)] text-white"
+                  >
+                    <div className="flex-1">
+                      <h3 className="font-semibold text-base">{party.title}</h3>
+                      {formattedDate && (
+                        <p className="text-sm text-white/80 mt-1">{formattedDate}</p>
+                      )}
+                    </div>
+                    <Button
+                      onClick={() => handleTicketScan(party.id)}
+                      className="ml-4 bg-gray-100 text-gray-700 hover:bg-gray-200 flex items-center gap-2"
+                    >
+                      <QrCode size={16} />
+                      <span>티켓 스캔</span>
+                    </Button>
+                  </div>
+                );
+              })}
+            </div>
+          </div>
+        )}
+      </StatusHandler>
+    </div>
+  );
+}

--- a/src/pages/inspection-ticket/PartyClothingListPage.tsx
+++ b/src/pages/inspection-ticket/PartyClothingListPage.tsx
@@ -1,0 +1,254 @@
+import { useState, useMemo, useEffect, useRef } from "react";
+import { useParams } from "react-router-dom";
+import { useQueryClient } from "@tanstack/react-query";
+import { Search, QrCode } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import StatusHandler from "@/components/common/StatusHandler";
+import { useGetPartyClothingItems } from "@/hooks/inspection/useGetPartyClothingItems";
+import { useUseVoucher } from "@/hooks/inspection/useUseVoucher";
+import { CLOTHING_CATEGORIES } from "@/types/clothingCategory";
+import { findCategoryByCode } from "@/utils/apply/clothingUtils";
+import type { ClothingCategoryCode } from "@/types/clothingCategory";
+import type { PartyClothingItem } from "@/apis/inspection/getPartyClothingItems";
+import defaultImage from "@/assets/images/default.png";
+import { TicketScanView } from "@/components/inspection-ticket/TicketScanView";
+
+export default function PartyClothingListPage() {
+  const { partyId } = useParams<{ partyId: string }>();
+  const queryClient = useQueryClient();
+
+  const [searchQuery, setSearchQuery] = useState("");
+  const [debouncedSearchKeyword, setDebouncedSearchKeyword] = useState<string>("");
+  const [selectedCategory, setSelectedCategory] = useState<string | null>(null);
+  const [selectedClothingNumber, setSelectedClothingNumber] = useState<string | null>(null);
+  const [isScanViewOpen, setIsScanViewOpen] = useState(false);
+  const debounceTimerRef = useRef<number | null>(null);
+
+  const useVoucherMutation = useUseVoucher();
+
+  // 검색어가 2자 이상일 때만 searchKeyword로 전달
+  const searchKeyword = debouncedSearchKeyword.length >= 2 ? debouncedSearchKeyword : undefined;
+
+  const { data, isLoading, isError, error } = useGetPartyClothingItems(partyId || "", {
+    searchKeyword,
+  });
+
+  // 카테고리 목록 생성 (모든 카테고리 표시)
+  const categories = useMemo(() => {
+    const allCategories: Array<{ code: string; label: string }> = [];
+    Object.values(CLOTHING_CATEGORIES).forEach((group) => {
+      group.categories.forEach((cat) => {
+        allCategories.push({
+          code: cat.code,
+          label: cat.subCategory,
+        });
+      });
+    });
+    return allCategories;
+  }, []);
+
+  // 검색 입력 핸들러 (즉시 반영, debounce로 API 호출 제어)
+  const handleSearchChange = (value: string) => {
+    // 입력은 즉시 반영
+    setSearchQuery(value);
+
+    // 기존 타이머 취소
+    if (debounceTimerRef.current) {
+      clearTimeout(debounceTimerRef.current);
+    }
+
+    // 500ms 후에 debouncedSearchKeyword 업데이트 (API 호출 트리거)
+    debounceTimerRef.current = setTimeout(() => {
+      setDebouncedSearchKeyword(value);
+    }, 500);
+  };
+
+  // 카테고리 선택 시 검색창에 코드 자동 입력 및 API 호출
+  const handleCategorySelect = (categoryCode: string) => {
+    const isSelected = selectedCategory === categoryCode;
+    if (isSelected) {
+      // 이미 선택된 카테고리를 다시 클릭하면 선택 해제
+      setSelectedCategory(null);
+      handleSearchChange("");
+    } else {
+      // 카테고리 선택 시 검색창에 코드 입력 (2자이므로 자동으로 API 호출됨)
+      setSelectedCategory(categoryCode);
+      handleSearchChange(categoryCode);
+    }
+  };
+
+  // 검색창 변경 시 카테고리 선택 해제 (검색어가 카테고리 코드와 다를 때)
+  useEffect(() => {
+    if (selectedCategory && searchQuery !== selectedCategory) {
+      setSelectedCategory(null);
+    }
+  }, [searchQuery, selectedCategory]);
+
+  // 컴포넌트 언마운트 시 타이머 정리
+  useEffect(() => {
+    return () => {
+      if (debounceTimerRef.current) {
+        clearTimeout(debounceTimerRef.current);
+      }
+    };
+  }, []);
+
+  // 필터링된 의류 목록
+  const filteredItems = data ?? [];
+
+  const handleTicketScan = (clothingNumber: string) => {
+    setSelectedClothingNumber(clothingNumber);
+    setIsScanViewOpen(true);
+  };
+
+  const handleScanSuccess = async (qrCode: string) => {
+    try {
+      // API 호출
+      await useVoucherMutation.mutateAsync({
+        voucherQrCode: qrCode,
+        partyId: partyId || "",
+        takenClothingNumber: selectedClothingNumber || undefined,
+      });
+
+      // 성공 시 의류 목록 페이지로 이동 (현재 페이지 유지)
+      setIsScanViewOpen(false);
+      setSelectedClothingNumber(null);
+      // 쿼리 무효화로 목록 갱신
+      queryClient.invalidateQueries({ queryKey: ["partyClothingItems"] });
+    } catch (error) {
+      // 실패 시 alert 표시하고 스캔 화면 유지
+      alert("티켓 사용에 실패했습니다. 다시 시도해주세요.");
+      console.error("티켓 사용 실패:", error);
+    }
+  };
+
+  const handleSkip = () => {
+    setSelectedClothingNumber(null);
+    setIsScanViewOpen(true);
+  };
+
+  return (
+    <>
+      <div className='flex flex-col h-full'>
+        {/* 검색 바 */}
+        <div className='px-5 pt-4 pb-3'>
+          <div className='relative'>
+            <Search
+              className='absolute left-3 top-1/2 transform -translate-y-1/2 text-gray-400'
+              size={20}
+            />
+            <input
+              type='text'
+              value={searchQuery}
+              onChange={(e) => handleSearchChange(e.target.value)}
+              placeholder='의류코드를 검색해 주세요'
+              className='w-full pl-10 pr-4 py-3 rounded-lg border border-gray-200 focus:outline-none focus:ring-2 focus:ring-[var(--color-purple-dark)]'
+            />
+          </div>
+        </div>
+
+        {/* 카테고리 필터 */}
+        <div className='px-5 pb-4'>
+          <div className='flex gap-2 overflow-x-auto scrollbar-hide'>
+            {categories.map((category) => {
+              const isSelected = selectedCategory === category.code;
+              return (
+                <button
+                  key={category.code}
+                  onClick={() => handleCategorySelect(category.code)}
+                  className={`px-4 py-2 rounded-lg text-sm font-medium whitespace-nowrap transition-colors ${
+                    isSelected
+                      ? "bg-[var(--color-purple-dark)] text-white"
+                      : "bg-white text-gray-700 border border-gray-300"
+                  }`}
+                >
+                  {category.label}
+                </button>
+              );
+            })}
+          </div>
+        </div>
+
+        {/* 의류 목록 (로딩 상태는 여기만 표시) */}
+        <div className='flex-1 overflow-y-auto px-5 pb-24'>
+          <StatusHandler isLoading={isLoading} isError={isError} error={error}>
+            {!searchKeyword ? (
+              <div className='flex flex-col items-center justify-center h-full text-gray-400'>
+                <p>의류코드를 검색해 주세요</p>
+              </div>
+            ) : filteredItems.length === 0 ? (
+              <div className='flex flex-col items-center justify-center h-full text-gray-400'>
+                <p>검색 결과가 없습니다.</p>
+              </div>
+            ) : (
+              <div className='flex flex-col gap-4'>
+                {filteredItems.map((item: PartyClothingItem) => (
+                  <div
+                    key={item.clothingNumber}
+                    className='flex gap-4 items-center p-3 rounded-lg border border-gray-200'
+                  >
+                    {/* 이미지 */}
+                    <div className='w-20 h-20 rounded-lg overflow-hidden bg-gray-100 flex-shrink-0'>
+                      <img
+                        src={item.imageUrls?.[0] || defaultImage}
+                        alt={item.clothingNumber}
+                        className='w-full h-full object-cover'
+                        onError={(e) => {
+                          e.currentTarget.src = defaultImage;
+                        }}
+                      />
+                    </div>
+
+                    {/* 정보 */}
+                    <div className='flex-1 min-w-0'>
+                      <p className='font-medium text-gray-900 truncate'>{item.clothingNumber}</p>
+                      <p className='text-sm text-gray-500'>
+                        {(() => {
+                          const categoryInfo = findCategoryByCode(
+                            item.category as ClothingCategoryCode
+                          );
+                          return categoryInfo
+                            ? `${categoryInfo.mainCategory} · ${categoryInfo.subCategory}`
+                            : item.category;
+                        })()}
+                      </p>
+                    </div>
+
+                    {/* 티켓 스캔 버튼 */}
+                    <Button
+                      onClick={() => handleTicketScan(item.clothingNumber)}
+                      className='bg-gray-100 text-gray-700 hover:bg-gray-200 flex items-center gap-2 whitespace-nowrap'
+                    >
+                      <QrCode size={16} />
+                      <span>티켓 스캔</span>
+                    </Button>
+                  </div>
+                ))}
+              </div>
+            )}
+          </StatusHandler>
+        </div>
+
+        {/* 건너뛰기 버튼 */}
+        <div className='fixed bottom-0 left-0 right-0 p-5 bg-white border-t border-gray-200 max-w-[430px] mx-auto'>
+          <Button theme='purple' onClick={handleSkip} className='w-full py-4 rounded-xl'>
+            건너뛰기
+          </Button>
+        </div>
+      </div>
+
+      {/* 티켓 스캔 뷰 */}
+      {isScanViewOpen && (
+        <TicketScanView
+          partyId={partyId || ""}
+          clothingNumber={selectedClothingNumber || undefined}
+          onClose={() => {
+            setIsScanViewOpen(false);
+            setSelectedClothingNumber(null);
+          }}
+          onScanSuccess={handleScanSuccess}
+        />
+      )}
+    </>
+  );
+}

--- a/src/routes/userRoutes.tsx
+++ b/src/routes/userRoutes.tsx
@@ -29,6 +29,8 @@ import {
   ImpactReceiptPage,
   SettingsPage,
   UserProfilePage,
+  InspectionTicketPage,
+  PartyClothingListPage,
 } from "@/pages";
 import ChatPageWrapper from "@/pages/chat/ChatPageWrapper";
 import PartyChatPageWrapper from "@/pages/chat/PartyChatPageWrapper";
@@ -306,6 +308,27 @@ const userRoutes: RouteObject = {
         },
       ],
     }, // /impact/receipt
+
+    // Inspection Ticket
+    {
+      path: "inspection-ticket",
+      children: [
+        {
+          index: true,
+          element: <InspectionTicketPage />,
+          handle: {
+            header: { type: "base", label: "의류추적", showBack: true },
+          },
+        },
+        {
+          path: ":partyId",
+          element: <PartyClothingListPage />,
+          handle: {
+            header: { type: "base", label: "파티명", showBack: true },
+          },
+        },
+      ],
+    }, // /inspection-ticket, /inspection-ticket/:partyId
   ],
 };
 


### PR DESCRIPTION
# 의류 추적(티켓 스캔) 기능 구현

## 📋 개요
파티 주최자가 의류 추적을 위한 티켓 스캔 기능을 사용할 수 있는 페이지를 구현했습니다.

## ✨ 주요 기능

### 1. 의류 추적 페이지 (`/inspection-ticket`)
- 주최한 파티 목록 조회
- 각 파티별 "티켓 스캔" 버튼 제공
- 파티가 없을 경우 파티 주최하기 안내

### 2. 의류 목록 페이지 (`/inspection-ticket/:partyId`)
- **검색 기능**
  - 의류코드 검색 (2자 이상 입력 시 API 호출)
  - 카테고리 필터 (소분류 선택 시 검색창에 코드 자동 입력)
  - 입력은 즉시 반영, API 호출은 debounce로 최적화 (500ms)
  - 로딩 상태는 의류 리스트 영역에만 표시

- **의류 목록**
  - 검색 결과 의류 목록 표시
  - 각 의류별 "티켓 스캔" 버튼
  - "건너뛰기" 버튼 (의류 선택 없이 티켓 스캔)

### 3. 티켓 스캔 기능
- QR 코드 스캔을 통한 티켓 사용
- 카메라 권한 처리 및 에러 핸들링
- 스캔 성공 시 의류 목록 자동 갱신
- 스캔 실패 시 알림 표시 및 스캔 화면 유지

## 🔧 기술적 개선사항

### 검색 최적화
- `onChange` 핸들러에서 직접 debounce 처리
- 입력은 즉시 반영되어 사용자 경험 개선
- API 호출은 입력이 멈춘 후 500ms 뒤에만 실행
- 로딩 상태를 의류 리스트 영역에만 표시하여 검색 중에도 입력 가능

### 카메라 스캔 개선
- DOM 준비 대기 (300ms 지연)
- `aspectRatio: 1` 설정으로 카메라 비율 고정
- 스캐너 시작 전 기존 스캐너 정리 로직 추가
- 컴포넌트 언마운트 시 리소스 정리

### 헤더 동적 표시
- `/inspection-ticket/:partyId` 경로에서 실제 파티명 표시
- `useGetParty` 훅을 활용한 파티 정보 조회

## 📡 API 통합

### 새로운 API
- `GET /api/inspection/available-clothes`
  - 파티별 의류 목록 조회
  - 쿼리 파라미터: `partyId`, `searchKeyword`
  
- `POST /api/inspection/vouchers/use`
  - 티켓 사용 처리
  - 쿼리 파라미터: `voucherQrCode`, `partyId`, `takenClothingNumber` (선택)

## 🐛 버그 수정
- TypeScript 타입 에러 수정
  - `patchTax` 파라미터 미사용 경고 해결
  - `BoardDetailHeader` createdAt null 체크 추가
  - `usePatchTax` 타입 가드 추가
- 사용하지 않는 import 제거
  - `ExchangeRequestPage`: `baseAreas` 변수 제거
  - `ImpactReceiptPage`: `FilterHeader` import 제거

## 📁 파일 구조

### 새로 추가된 파일
```
src/
├── apis/inspection/
│   ├── getPartyClothingItems.ts
│   └── useVoucher.ts
├── hooks/inspection/
│   ├── useGetPartyClothingItems.ts
│   └── useUseVoucher.ts
├── hooks/common/
│   ├── useDebounce.ts
│   └── useThrottle.ts
├── components/inspection-ticket/
│   └── TicketScanView.tsx
└── pages/inspection-ticket/
    ├── InspectionTicketPage.tsx
    └── PartyClothingListPage.tsx
```

## 🎯 사용자 시나리오

1. **파티 주최자**가 `/inspection-ticket`에 접속
2. 주최한 파티 목록에서 원하는 파티 선택
3. 의류코드 검색 또는 카테고리 필터로 의류 찾기
4. 의류 선택 후 "티켓 스캔" 또는 "건너뛰기" 버튼 클릭
5. QR 코드 스캔으로 티켓 사용 처리
6. 성공 시 의류 목록 자동 갱신

## 🔍 테스트 체크리스트
- [x] 파티 목록 조회 및 표시
- [x] 의류코드 검색 (2자 이상)
- [x] 카테고리 필터 선택 및 해제
- [x] 검색 입력 debounce 동작
- [x] 티켓 스캔 (의류 선택)
- [x] 티켓 스캔 (건너뛰기)
- [x] 카메라 권한 에러 처리
- [x] 스캔 성공/실패 처리
- [x] 헤더 동적 파티명 표시
